### PR TITLE
fix: Don't extract the schema on production builds

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,10 +22,6 @@
             "error",
             "always"
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
         "indent": [
             "error",
             4,

--- a/gatsby-config.esm.js
+++ b/gatsby-config.esm.js
@@ -58,9 +58,12 @@ const config = {
             }
         },
         "gatsby-plugin-eslint",
-        "gatsby-plugin-sass",
-        "gatsby-plugin-extract-schema"
+        "gatsby-plugin-sass"
     ]
 };
+
+if (process.env.NODE_ENV === "development") {
+    config.plugins.push("gatsby-plugin-extract-schema");
+}
 
 export default config;


### PR DESCRIPTION
* Also no longer lint linebreaks because Git converts them for us.