### PR TITLE
fix(gh-pages): Don't fail if no announcement table exists

### DIFF
--- a/plugins/gatsby-source-animethemes-db/src/source-nodes.js
+++ b/plugins/gatsby-source-animethemes-db/src/source-nodes.js
@@ -144,12 +144,16 @@ module.exports = async ({ actions, createNodeId, createContentDigest, reporter }
         }, "Image", helpers);
     }
 
-    for (const announcement of await query("SELECT * FROM announcement")) {
-        createNodeFromData({
-            id: announcement.announcement_id,
-            idRaw: announcement.announcement_id,
-            content: announcement.content
-        }, "Announcement", helpers);
+    try {
+        for (const announcement of await query("SELECT * FROM announcement")) {
+            createNodeFromData({
+                id: announcement.announcement_id,
+                idRaw: announcement.announcement_id,
+                content: announcement.content
+            }, "Announcement", helpers);
+        }
+    } catch (e) {
+        reporter.warn("Error while getting announcements. This should only happen on GitHub pages.");
     }
 
     // Pivot types

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -149,10 +149,9 @@ export default function IndexPage({ data: { site, allAnnouncement } }) {
                     <Text as="p">
                         <span>You are browsing this site on GitHub Pages. On every commit in the </span>
                         <Text as="a" variant="code" link href="https://github.com/AnimeThemes/animethemes-web">animethemes-web</Text>
-                        <span> repository this site gets updated. This also comes with some limitations like </span>
-                        <Text variant="code">.htaccess</Text>
-                        <span> files not working. So don&apos;t expect everything on this site to work the same way as on the production site.</span>
+                        <span> repository this site gets updated.</span>
                     </Text>
+                    <Text as="p">Don&apos;t expect everything on this site to work the same way as on the staging/production sites.</Text>
                 </>
             )}
         </Box>


### PR DESCRIPTION
* Also updated the section on GitHub pages on the home page.