### PR TITLE
#71 fix: Video pages no longer crash on iOS devices

### DIFF
--- a/src/components/button/VideoButton.js
+++ b/src/components/button/VideoButton.js
@@ -18,7 +18,7 @@ export function VideoButton({ anime, theme, entry, video, ...props }) {
                 <Button as="span" variant="primary">
                     <Icon icon={isPlaying ? faCompactDisc : faPlay} spin={isPlaying}/>
                 </Button>
-                <VideoTags video={video}/>
+                <VideoTags video={video} hideTextOnMobile/>
             </Button>
         </Link>
     );

--- a/src/components/utils/VideoTags.js
+++ b/src/components/utils/VideoTags.js
@@ -9,7 +9,7 @@ import {
 import { Tag } from "components/tag";
 import { Flex } from "components/box";
 
-export function VideoTags({ video }) {
+export function VideoTags({ video, hideTextOnMobile }) {
     return (
         <div>
             <Flex flexWrap="wrap" gapsBoth="0.5rem">
@@ -40,7 +40,7 @@ export function VideoTags({ video }) {
                 )}
 
                 {video.overlap !== "None" && (
-                    <Tag icon={faStream} title="Overlap" hideTextOnMobile>
+                    <Tag icon={faStream} title="Overlap" hideTextOnMobile={hideTextOnMobile}>
                         {video.overlap.toUpperCase()}
                     </Tag>
                 )}

--- a/src/components/video-player/VideoPlayer.js
+++ b/src/components/video-player/VideoPlayer.js
@@ -1,25 +1,37 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import {
     StyledPlayer,
     StyledPlayerButton,
     StyledVideo,
     StyledOverlay
 } from "./VideoPlayer.style";
-import { faExpandAlt, faPause, faPlay, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faExpandAlt, faPause, faPlay, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { navigate } from "gatsby";
 import PlayerContext from "context/playerContext";
 import createVideoSlug from "utils/createVideoSlug";
 import { useMedia } from "use-media";
 import { Icon } from "components/icon";
 import { AspectRatio } from "components/utils";
+import { Button } from "components/button";
+import { Card } from "components/card";
+import { Text } from "components/text";
+import { Flex } from "components/box";
 
 const videoBaseUrl = process.env.GATSBY_VIDEO_URL || "https://animethemes.moe";
 
 export function VideoPlayer({ video, entry, background, ...props }) {
     const [isPlaying, setPlaying] = useState(false);
+    const [canPlay, setCanPlay] = useState(true);
     const playerRef = useRef();
     const { setCurrentVideo } = useContext(PlayerContext);
     const isMobile = useMedia({ maxWidth: "720px" });
+    const videoUrl = `${videoBaseUrl}/video/${video.basename}`;
+
+    useEffect(() => {
+        if (playerRef.current) {
+            setCanPlay(!!playerRef.current.canPlayType("video/webm"));
+        }
+    }, []);
 
     function togglePlay() {
         if (isPlaying) {
@@ -52,19 +64,49 @@ export function VideoPlayer({ video, entry, background, ...props }) {
 
             {...props}
         >
-            <AspectRatio ratio={16 / 9}>
-                <StyledVideo
-                    ref={playerRef}
-                    src={`${videoBaseUrl}/video/${video.basename}`}
-                    controls={!background}
-                    autoPlay
-                    onPlay={() => setPlaying(true)}
-                    onPause={() => setPlaying(false)}
-                    onEnded={() => setPlaying(false)}
-                >
-                    Your browser doesn&apos;t support HTML5 video playback. Please use a modern browser.
-                </StyledVideo>
-            </AspectRatio>
+            {!!canPlay ? (
+                <AspectRatio ratio={16 / 9}>
+                    <StyledVideo
+                        ref={playerRef}
+                        src={videoUrl}
+                        controls={!background}
+                        autoPlay
+                        onPlay={() => setPlaying(true)}
+                        onPause={() => setPlaying(false)}
+                        onEnded={() => setPlaying(false)}
+                    >
+                        Your browser doesn&apos;t support HTML5 video playback. Please use a modern browser.
+                    </StyledVideo>
+                </AspectRatio>
+            ) : (
+                <Card gapsColumn="1rem" m="1rem">
+                    <Text as="p">Your browser or device doesn&apos;t seem to support WebM video which is required to play video files.</Text>
+                    <Text as="p">You can try one of the options below to still watch the video:</Text>
+                    <div>
+                        <Flex gapsBoth="1rem" flexWrap="wrap">
+                            <Button
+                                as="a"
+                                variant="on-card"
+                                href={`vlc-x-callback://x-callback-url/stream?url=${videoUrl}`}
+                                gapsRow="0.5rem"
+                            >
+                                <Icon icon={faPlay} color="text-disabled"/>
+                                <Text>Play in VLC</Text>
+                            </Button>
+                            <Button
+                                as="a"
+                                variant="on-card"
+                                href={videoUrl}
+                                download
+                                gapsRow="0.5rem"
+                            >
+                                <Icon icon={faDownload} color="text-disabled"/>
+                                <Text>Download</Text>
+                            </Button>
+                        </Flex>
+                    </div>
+                </Card>
+            )}
             {background && (
                 <StyledOverlay force={!isPlaying}>
                     <StyledPlayerButton onClick={() => setCurrentVideo(null)}>

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -28,7 +28,7 @@ export default createGlobalStyle`
     body {
         margin: 0;
 
-        background-color: ${theme.colors["background"]};
+        background-color: ${theme.colors["solid"]};
         color: ${theme.colors["text"]};
 
         font-family: "Nunito", sans-serif;

--- a/src/templates/video.js
+++ b/src/templates/video.js
@@ -26,7 +26,7 @@ export default function VideoPage({ data: { video, entry } }) {
     const { smallCover } = useImage(anime);
 
     useEffect(() => {
-        if (theme && smallCover) {
+        if (theme && smallCover && navigator.mediaSession) {
             // eslint-disable-next-line no-undef
             navigator.mediaSession.metadata = new MediaMetadata({
                 title: `${theme.slug} • ${theme.song.title}`,


### PR DESCRIPTION
* Added info card with alternatives if videos can't be played on device.
* Background above header and below footer now match the adjacent colors.
* Fixed video tags also collapsing on video page.