### PR TITLE
feat: Anime summary cards can now be expanded to a table

### DIFF
--- a/src/components/card/AnimeSummaryCard.js
+++ b/src/components/card/AnimeSummaryCard.js
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import Link from "next/link";
 import { faChevronDown, faPlay } from "@fortawesome/free-solid-svg-icons";
 import { Button } from "components/button";
@@ -7,17 +8,18 @@ import createVideoSlug from "utils/createVideoSlug";
 import { Icon } from "components/icon";
 import { SummaryCard } from "components/card";
 import { chain, themeIndexComparator, themeTypeComparator } from "utils/comparators";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import useToggle from "hooks/useToggle";
-import { motion } from "framer-motion";
 import theme from "theme";
 import gql from "graphql-tag";
+import { uniq } from "lodash-es";
+import { Collapse, ThemeEntryTags, VideoTags } from "components/utils";
+import { withHover } from "styles/mixins";
 
 const StyledThemeContainerInline = styled.div`
     display: flex;
     flex-wrap: wrap;
-    
-    gap: 0.75rem;
+    gap: 12px;
 
     user-select: none;
     
@@ -26,15 +28,34 @@ const StyledThemeContainerInline = styled.div`
     }
 `;
 
-const StyledThemeContainer = styled(StyledThemeContainerInline)`
-    margin-top: -1rem;
-    padding-top: 2rem;
-    gap: 1rem;
+const StyledThemeGroupContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 16px;
 `;
 
-export function AnimeSummaryCard({ anime, hideThemes = false, maxThemes = 2, ...props }) {
+const StyledThemeRow = styled.a`
+    display: grid;
+    grid-template-columns: 56px 2fr 1fr 1fr;
+    grid-gap: 8px;
+    align-items: baseline;
+    padding: 8px 4px;
+    
+    &:not(:last-of-type) {
+        border-bottom: 1px solid ${theme.colors["text-disabled"]};   
+    }
+    
+    ${withHover(css`
+        background-color: ${theme.colors["solid"]};
+    `)}
+`;
+
+export function AnimeSummaryCard({ anime, previewThemes = false, expandable = false, ...props }) {
     const { smallCover } = useImage(anime);
     const [ showAllThemes, toggleShowAllThemes ] = useToggle();
+
+    const groups = uniq(anime.themes.map((theme) => theme.group));
 
     const animeLink = `/anime/${anime.slug}`;
 
@@ -66,12 +87,12 @@ export function AnimeSummaryCard({ anime, hideThemes = false, maxThemes = 2, ...
                 to={animeLink}
                 {...props}
             >
-                {!hideThemes && (
+                {(previewThemes || expandable) && (
                     <StyledThemeContainerInline>
-                        {!showAllThemes && (
-                            <Themes anime={anime} maxThemes={maxThemes}/>
+                        {previewThemes && !showAllThemes && (
+                            <ThemesInline anime={anime} maxThemes={previewThemes === true ? 2 : previewThemes}/>
                         )}
-                        {anime.themes.length > maxThemes && (
+                        {expandable && (
                             <Button as="a" variant="silent" isCircle title="Show all themes" onClick={toggleShowAllThemes}>
                                 <Icon icon={faChevronDown} rotation={showAllThemes ? 180 : 0} transition="transform 400ms"/>
                             </Button>
@@ -79,32 +100,29 @@ export function AnimeSummaryCard({ anime, hideThemes = false, maxThemes = 2, ...
                     </StyledThemeContainerInline>
                 )}
             </SummaryCard>
-            {showAllThemes && (
-                <StyledThemeContainer
-                    as={motion.div}
-                    variants={{
-                        show: {
-                            transition: {
-                                staggerChildren: 0.04
-                            }
-                        }
-                    }}
-                    initial="hidden"
-                    animate="show"
-                    layoutDependency={showAllThemes}
-                >
-                    <Themes anime={anime}/>
-                </StyledThemeContainer>
+            {expandable && (
+                <Collapse collapse={!showAllThemes}>
+                    <StyledThemeGroupContainer>
+                        {groups.map((group) => (
+                            <Fragment key={group}>
+                                {!!group && (
+                                    <Text variant="h2">{group}</Text>
+                                )}
+                                <ThemesTable anime={anime} group={group}/>
+                            </Fragment>
+                        ))}
+                    </StyledThemeGroupContainer>
+                </Collapse>
             )}
         </div>
     );
 }
 
-function Themes({ anime, maxThemes = false }) {
+function ThemesInline({ anime, maxThemes }) {
     return anime.themes
         .filter((theme) => "entries" in theme && theme.entries.length && theme.entries[0].videos.length)
-        .sort(chain(themeTypeComparator, themeIndexComparator))
-        .slice(0, maxThemes !== false ? maxThemes : anime.themes.length)
+        .sort(chain(themeIndexComparator, themeTypeComparator))
+        .slice(0, maxThemes)
         .map((theme) => {
             const entry = theme.entries[0];
             const video = entry.videos[0];
@@ -112,20 +130,7 @@ function Themes({ anime, maxThemes = false }) {
 
             return (
                 <Link key={theme.slug + theme.group} href={`/anime/${anime.slug}/${videoSlug}`} passHref>
-                    <Button
-                        as={motion.a}
-                        layoutId={anime.slug + theme.slug}
-                        layoutDependency={0}
-                        variants={{
-                            hidden: {
-                                opacity: 0, y: -32
-                            },
-                            show: {
-                                opacity: 1, y: 0
-                            }
-                        }}
-                        transition={{ duration: 0.4 }}
-                    >
+                    <Button as="a">
                         <Button as="span" variant="primary" isCircle>
                             <Icon icon={faPlay}/>
                         </Button>
@@ -136,30 +141,108 @@ function Themes({ anime, maxThemes = false }) {
         });
 }
 
-AnimeSummaryCard.fragment = gql`
-    ${useImage.fragment}
-    ${createVideoSlug.fragments.theme}
-    ${createVideoSlug.fragments.entry}
-    ${createVideoSlug.fragments.video}
-    
-    fragment AnimeSummaryCard_anime on Anime {
-        ...useImage_resourceWithImages
-        slug
-        name
-        year
-        season
-        themes {
-            ...createVideoSlug_theme
+function ThemesTable({ anime, group = null }) {
+    const rows = anime.themes
+        .filter((theme) => theme.group === group && "entries" in theme && theme.entries.length && theme.entries[0].videos.length)
+        .sort(chain(themeTypeComparator, themeIndexComparator))
+        .map((theme) => theme.entries.map((entry, entryIndex) => entry.videos.map((video, videoIndex) => {
+            const videoSlug = createVideoSlug(theme, entry, video);
+
+            return (
+                <Link key={theme.slug + theme.group} href={`/anime/${anime.slug}/${videoSlug}`} passHref>
+                    <StyledThemeRow>
+                        {!videoIndex ? (
+                            entry.version > 1 ? (
+                                <Text variant="small" color="text-muted">{theme.type}{theme.sequence || null} v{entry.version}</Text>
+                            ) : (
+                                <Text variant="small">{theme.type}{theme.sequence || null}</Text>
+                            )
+                        ) : (
+                            <span/>
+                        )}
+                        {(!entryIndex && !videoIndex) ? (
+                            <Text link>{!entryIndex && !videoIndex && theme.song.title}</Text>
+                        ) : (
+                            <span/>
+                        )}
+                        {!videoIndex ? (
+                            <ThemeEntryTags entry={entry}/>
+                        ) : (
+                            <span/>
+                        )}
+                        <VideoTags video={video}/>
+                    </StyledThemeRow>
+                </Link>
+            );
+        })));
+
+    return (
+        <div>
+            {rows}
+        </div>
+    );
+}
+
+AnimeSummaryCard.fragments = {
+    anime: gql`
+        ${useImage.fragment}
+        
+        fragment AnimeSummaryCard_anime on Anime {
+            ...useImage_resourceWithImages
             slug
-            group
-            type
-            sequence
-            entries {
-                ...createVideoSlug_entry
-                videos {
-                    ...createVideoSlug_video
+            name
+            year
+            season
+        }
+    `,
+    previewThemes: gql`
+        ${createVideoSlug.fragments.theme}
+        ${createVideoSlug.fragments.entry}
+        ${createVideoSlug.fragments.video}
+
+        fragment AnimeSummaryCard_anime_previewThemes on Anime {
+            themes {
+                ...createVideoSlug_theme
+                slug
+                group
+                type
+                sequence
+                entries {
+                    ...createVideoSlug_entry
+                    videos {
+                        ...createVideoSlug_video
+                    }
                 }
             }
         }
-    }
-`;
+    `,
+    expandable: gql`
+        ${createVideoSlug.fragments.theme}
+        ${createVideoSlug.fragments.entry}
+        ${createVideoSlug.fragments.video}
+        ${VideoTags.fragment}
+        ${ThemeEntryTags.fragment}
+
+        fragment AnimeSummaryCard_anime_expandable on Anime {
+            themes {
+                ...createVideoSlug_theme
+                slug
+                group
+                type
+                sequence
+                entries {
+                    ...createVideoSlug_entry
+                    ...ThemeEntryTags_entry
+                    version
+                    videos {
+                        ...createVideoSlug_video
+                        ...VideoTags_video
+                    }
+                }
+                song {
+                    title
+                }
+            }
+        }
+    `
+};

--- a/src/components/listbox/ListboxNative.js
+++ b/src/components/listbox/ListboxNative.js
@@ -108,7 +108,7 @@ export function ListboxNative({ children, value, onChange, resettable, defaultVa
     );
 }
 
-ListboxNative.Option = function ListboxNativeOption({ value, children }) {
+ListboxNative.Option = function ListboxNativeOption({ value = null, children }) {
     const { setLabel, removeLabel } = useContext(ListboxContext);
 
     useEffect(() => {

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -32,7 +32,7 @@ const StyledMenuItems = styled(MenuItems)`
         z-index: ${theme.zIndices.toast};
         background-color: ${theme.colors["solid"]};
         box-shadow: ${theme.shadows.high};
-        animation: ${slideIn} 200ms both;
+        animation: ${slideIn()} 200ms both;
     }
 `;
 const StyledMenuItem = styled(MenuItem)`

--- a/src/components/search/SearchAnime.js
+++ b/src/components/search/SearchAnime.js
@@ -51,7 +51,7 @@ export function SearchAnime({ searchQuery }) {
                     </SearchFilterSortBy>
                 </>
             }
-            renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime}/>}
+            renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>}
             {...entitySearch}
         />
     );

--- a/src/components/search/SearchGlobal.js
+++ b/src/components/search/SearchGlobal.js
@@ -68,7 +68,7 @@ export function SearchGlobal({ searchQuery }) {
                 entity="anime"
                 title="Anime"
                 results={animeResults}
-                renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime}/>}
+                renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>}
             />
             <GlobalSearchSection
                 entity="theme"

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -6,8 +6,12 @@ import theme from "theme";
 const StyledTag = styled.span`
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: baseline;
     gap: 4px;
+    
+    & ${Icon} {
+        transform: translateY(0.2rem);
+    }
 `;
 
 const StyledText = styled(Text)`    

--- a/src/components/text/Text.js
+++ b/src/components/text/Text.js
@@ -40,6 +40,7 @@ export const Text = styled.span.attrs(getAttributes)`
         border-radius: 0.25rem;
         background-color: ${theme.colors["solid"]};
         box-shadow: ${theme.shadows.low};
+        box-decoration-break: clone;
     `}
 
     ${(props) => props.link && css`

--- a/src/components/utils/Collapse.js
+++ b/src/components/utils/Collapse.js
@@ -1,4 +1,11 @@
-import { motion } from "framer-motion";
+import styled from "styled-components";
+import { fadeIn, slideIn } from "styles/animations";
+
+const StyledWrapper = styled.div`
+    animation-name: ${slideIn("-16px")}, ${fadeIn};
+    animation-duration: 350ms;
+    animation-timing-function: ease-out;
+`;
 
 export function Collapse({ collapse, children }) {
     if (collapse) {
@@ -6,12 +13,8 @@ export function Collapse({ collapse, children }) {
     }
 
     return (
-        <motion.div
-            initial={{ y: -20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            transition={{ type: "tween", duration: 0.35, ease: [ 0, 0.66, 0.46, 0.98 ] }}
-        >
+        <StyledWrapper>
             {children}
-        </motion.div>
+        </StyledWrapper>
     );
 }

--- a/src/components/utils/ThemeEntryTags.js
+++ b/src/components/utils/ThemeEntryTags.js
@@ -2,10 +2,11 @@ import { Tag } from "components/tag";
 import { faBomb, faExclamationTriangle, faFilm } from "@fortawesome/free-solid-svg-icons";
 import { Icon } from "components/icon";
 import { Row } from "components/box";
+import gql from "graphql-tag";
 
 export function ThemeEntryTags({ entry }) {
     return (
-        <Row style={{ "--gap": "8px" }}>
+        <Row style={{ "--gap": "8px", "--align-items": "baseline" }}>
             <Tag icon={faFilm}>
                 {entry.episodes || "—"}
             </Tag>
@@ -22,3 +23,11 @@ export function ThemeEntryTags({ entry }) {
         </Row>
     );
 }
+
+ThemeEntryTags.fragment = gql`
+    fragment ThemeEntryTags_entry on Entry {
+        episodes
+        spoiler
+        nsfw
+    }
+`;

--- a/src/components/utils/VideoTags.js
+++ b/src/components/utils/VideoTags.js
@@ -9,8 +9,10 @@ import {
 import { Tag } from "components/tag";
 import { Row } from "components/box";
 import styled from "styled-components";
+import gql from "graphql-tag";
 
 const StyledVideoTags = styled(Row)`
+    align-items: baseline;
     flex-wrap: wrap;
     gap: 8px;
 `;
@@ -52,3 +54,15 @@ export function VideoTags({ video, hideTextOnMobile }) {
         </StyledVideoTags>
     );
 }
+
+VideoTags.fragment = gql`
+    fragment VideoTags_video on Video {
+        resolution
+        nc
+        subbed
+        lyrics
+        uncen
+        source
+        overlap
+    }
+`;

--- a/src/components/video-player/VideoPlayer.style.js
+++ b/src/components/video-player/VideoPlayer.style.js
@@ -19,7 +19,7 @@ export const StyledPlayer = styled(motion.div)`
             
             background-color: ${theme.colors["solid"]};
 
-            animation: ${slideIn} 500ms ease;
+            animation: ${slideIn()} 500ms ease;
             
             & ${StyledVideo} {
                 width: auto;

--- a/src/pages/anime/[animeSlug]/[videoSlug]/index.js
+++ b/src/pages/anime/[animeSlug]/[videoSlug]/index.js
@@ -31,6 +31,7 @@ const StyledVideoInfo = styled.div`
 `;
 
 const StyledVideoEntryInfo = styled(Row)`
+    align-items: baseline;
     justify-content: flex-end;
     gap: 16px;
 
@@ -40,6 +41,7 @@ const StyledVideoEntryInfo = styled(Row)`
 `;
 
 const StyledVideoTagsInfo = styled(Row)`
+    align-items: baseline;
     justify-content: flex-end;
 `;
 
@@ -161,10 +163,10 @@ export default function VideoPage({ anime, theme, entry, video }) {
                         </Link>
                     </Text>
                 </Column>
-                <Text variant="small" color="text-muted">
+                <Text color="text-muted">
                     <Column style={{ "--gap": "4px" }}>
                         <StyledVideoEntryInfo>
-                            <Text>Version {entry.version || 1}</Text>
+                            <Text variant="small">Version {entry.version || 1}</Text>
                             <ThemeEntryTags entry={entry}/>
                         </StyledVideoEntryInfo>
                         <StyledVideoTagsInfo>
@@ -189,7 +191,7 @@ export default function VideoPage({ anime, theme, entry, video }) {
             <StyledRelatedGrid>
                 <Column style={{ "--gap": "16px" }}>
                     <Text variant="h2">Information</Text>
-                    <AnimeSummaryCard anime={anime} hideThemes/>
+                    <AnimeSummaryCard anime={anime}/>
                     {!!anime.series?.length && anime.series.map((series) => (
                         <SummaryCard key={series.slug} title={series.name} description="Series" to={`/series/${series.slug}`} />
                     ))}
@@ -240,9 +242,9 @@ export default function VideoPage({ anime, theme, entry, video }) {
                         <Column style={{ "--gap": "32px" }}>
                             {otherEntries.map((otherEntry) => (
                                 <StyledRelatedEntries key={otherEntry.version}>
-                                    <Text variant="small" color="text-muted">
-                                        <Row style={{ "--gap": "8px" }}>
-                                            <Text>Version {otherEntry.version || 1}</Text>
+                                    <Text color="text-muted">
+                                        <Row style={{ "--gap": "8px", "--align-items": "baseline" }}>
+                                            <Text variant="small">Version {otherEntry.version || 1}</Text>
                                             <ThemeEntryTags entry={otherEntry}/>
                                         </Row>
                                     </Text>

--- a/src/pages/artist/[artistSlug]/index.js
+++ b/src/pages/artist/[artistSlug]/index.js
@@ -26,6 +26,7 @@ import {
 import { fetchData } from "lib/server";
 import { SEO } from "components/seo";
 import useImage from "hooks/useImage";
+import gql from "graphql-tag";
 
 const StyledList = styled.div`
     display: flex;
@@ -175,11 +176,13 @@ export default function ArtistDetailPage({ artist }) {
 }
 
 export async function getStaticProps({ params: { artistSlug } }) {
-    const { data } = await fetchData(`
-        #graphql
+    const { data } = await fetchData(gql`
+        ${ThemeSummaryCard.fragments.theme}
+        ${ThemeSummaryCard.fragments.artist}
 
         query($artistSlug: String!) {
             artist(slug: $artistSlug) {
+                ...ThemeSummaryCard_artist
                 slug
                 name
                 performances {
@@ -194,24 +197,12 @@ export async function getStaticProps({ params: { artistSlug } }) {
                             as
                         }
                         themes {
+                            ...ThemeSummaryCard_theme
                             id
                             slug
                             group
                             anime {
                                 slug
-                                name
-                                year
-                                season
-                                images {
-                                    facet
-                                    link
-                                }
-                            }
-                            entries {
-                                version
-                                videos {
-                                    tags
-                                }
                             }
                         }
                     }

--- a/src/pages/design.js
+++ b/src/pages/design.js
@@ -406,7 +406,7 @@ export default function DesignPage({ demoData }) {
                 </pre>
                 <AnimeSummaryCard
                     anime={demoData.anime}
-                    maxThemes={1}
+                    previewThemes={1}
                 />
             </ExampleGrid>
 
@@ -638,11 +638,13 @@ function Color({ color }) {
 
 export async function getStaticProps() {
     const { data } = await fetchData(gql`
-        ${AnimeSummaryCard.fragment}
+        ${AnimeSummaryCard.fragments.anime}
+        ${AnimeSummaryCard.fragments.previewThemes}
         
         query {
             anime(slug: "bakemonogatari") {
                 ...AnimeSummaryCard_anime
+                ...AnimeSummaryCard_anime_previewThemes
             }
         }
     `);

--- a/src/pages/page/[...pageSlug].js
+++ b/src/pages/page/[...pageSlug].js
@@ -31,6 +31,7 @@ const StyledGrid = styled.div`
 
 const StyledMarkdown = styled.div`
     line-height: 1.75;
+    word-break: break-word;
     
     & h1 {
         margin-bottom: 32px;

--- a/src/pages/series/[seriesSlug]/index.js
+++ b/src/pages/series/[seriesSlug]/index.js
@@ -13,6 +13,7 @@ import { fetchData } from "lib/server";
 import { SEO } from "components/seo";
 import theme from "theme";
 import { MultiCoverImage } from "components/image";
+import gql from "graphql-tag";
 
 const StyledDesktopOnly = styled.div`
     gap: 24px;
@@ -58,7 +59,7 @@ export default function SeriesDetailPage({ series }) {
                     </Collapse>
                     <Column style={{ "--gap": "16px" }}>
                         {animeSorted.map((anime) => (
-                            <AnimeSummaryCard key={anime.slug} anime={anime}/>
+                            <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
                         ))}
                     </Column>
                 </Column>
@@ -68,14 +69,19 @@ export default function SeriesDetailPage({ series }) {
 }
 
 export async function getStaticProps({ params: { seriesSlug } }) {
-    const { data } = await fetchData(`
-        #graphql
+    const { data } = await fetchData(gql`
+        ${AnimeSummaryCard.fragments.anime}
+        ${AnimeSummaryCard.fragments.previewThemes}
+        ${AnimeSummaryCard.fragments.expandable}
 
         query($seriesSlug: String!) {
             series(slug: $seriesSlug) {
                 slug
                 name
                 anime {
+                    ...AnimeSummaryCard_anime
+                    ...AnimeSummaryCard_anime_previewThemes
+                    ...AnimeSummaryCard_anime_expandable
                     name
                     slug
                     year

--- a/src/pages/studio/[studioSlug]/index.js
+++ b/src/pages/studio/[studioSlug]/index.js
@@ -22,6 +22,7 @@ import { ExternalLink } from "components/external-link";
 import { SEO } from "components/seo";
 import theme from "theme";
 import { MultiCoverImage } from "components/image";
+import gql from "graphql-tag";
 
 const StyledDesktopOnly = styled.div`    
     @media (max-width: ${theme.breakpoints.tabletMax}) {
@@ -88,7 +89,7 @@ export default function StudioDetailPage({ studio }) {
                     </Collapse>
                     <Column style={{ "--gap": "16px" }}>
                         {animeSorted.map((anime) => (
-                            <AnimeSummaryCard key={anime.slug} anime={anime}/>
+                            <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
                         ))}
                     </Column>
                 </Column>
@@ -98,14 +99,19 @@ export default function StudioDetailPage({ studio }) {
 }
 
 export async function getStaticProps({ params: { studioSlug } }) {
-    const { data } = await fetchData(`
-        #graphql
+    const { data } = await fetchData(gql`
+        ${AnimeSummaryCard.fragments.anime}
+        ${AnimeSummaryCard.fragments.previewThemes}
+        ${AnimeSummaryCard.fragments.expandable}
 
         query($studioSlug: String!) {
             studio(slug: $studioSlug) {
                 slug
                 name
                 anime {
+                    ...AnimeSummaryCard_anime
+                    ...AnimeSummaryCard_anime_previewThemes
+                    ...AnimeSummaryCard_anime_expandable
                     name
                     slug
                     year

--- a/src/pages/year/[year]/[season]/index.js
+++ b/src/pages/year/[year]/[season]/index.js
@@ -22,7 +22,7 @@ export default function SeasonDetailPage({ animeAll, year, season }) {
             </Text>
             <Column style={{ "--gap": "16px" }}>
                 {animeList.map((anime) => (
-                    <AnimeSummaryCard key={anime.slug} anime={anime}/>
+                    <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
                 ))}
             </Column>
         </>
@@ -33,7 +33,9 @@ export async function getStaticProps({ params: { year, season } }) {
     year = +year;
 
     const { data } = await fetchData(gql`
-        ${AnimeSummaryCard.fragment}
+        ${AnimeSummaryCard.fragments.anime}
+        ${AnimeSummaryCard.fragments.previewThemes}
+        ${AnimeSummaryCard.fragments.expandable}
 
         query($year: Int = 0, $season: String!) {
             yearAll {
@@ -46,6 +48,8 @@ export async function getStaticProps({ params: { year, season } }) {
                 anime {
                     slug
                     ...AnimeSummaryCard_anime
+                    ...AnimeSummaryCard_anime_previewThemes
+                    ...AnimeSummaryCard_anime_expandable
                 }
             }
             

--- a/src/styles/animations.js
+++ b/src/styles/animations.js
@@ -17,9 +17,9 @@ export const fadeIn = keyframes`
     }
 `;
 
-export const slideIn = keyframes`
+export const slideIn = (y = "100%") => keyframes`
     from {
-        transform: translateY(100%);
+        transform: translateY(${y});
     }
 `;
 

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -85,6 +85,7 @@ export default createGlobalStyle`
 
     img, video {
         display: block;
+        max-width: 100%;
     }
 
     pre {


### PR DESCRIPTION
* All anime summary cards can now be expanded (before only ones with more than two themes could be).
* Anime summary cards now prefer to show the first OP and ED instead of the first two OPs.
* Streamlined collapse animations.
* Video and entry tags are now baseline aligned.
* Document pages: Inline code can now line-wrap.
* Document pages: Images no longer overflow.
* API requests now merge sparse fieldsets to prevent missing fields.
* Fixed wrong order of anime on year pages.
* Fixed issue with null values of listboxes on mobile.