### PR TITLE
feat: Added revalidate API route

### DIFF
--- a/src/components/button/VideoButton.js
+++ b/src/components/button/VideoButton.js
@@ -13,7 +13,7 @@ export function VideoButton({ anime, theme, entry, video, ...props }) {
     const isPlaying = currentVideo && currentVideo.filename === video.filename;
 
     return (
-        <Link href={`/anime/${anime.slug}/${videoSlug}`} passHref>
+        <Link href={`/anime/${anime.slug}/${videoSlug}`} passHref prefetch={false}>
             <Button as="a" {...props}>
                 <Button as="span" variant="primary" isCircle>
                     <Icon icon={isPlaying ? faCompactDisc : faPlay} spin={isPlaying}/>

--- a/src/components/card/AnimeSummaryCard.js
+++ b/src/components/card/AnimeSummaryCard.js
@@ -70,7 +70,7 @@ export function AnimeSummaryCard({ anime, previewThemes = false, expandable = fa
         <SummaryCard.Description>
             <span>Anime</span>
             {!!anime.year && (
-                <Link href={premiereLink} passHref>
+                <Link href={premiereLink} passHref prefetch={false}>
                     <Text as="a" link>{premiere}</Text>
                 </Link>
             )}
@@ -129,7 +129,7 @@ function ThemesInline({ anime, maxThemes }) {
             const videoSlug = createVideoSlug(theme, entry, video);
 
             return (
-                <Link key={theme.slug + theme.group} href={`/anime/${anime.slug}/${videoSlug}`} passHref>
+                <Link key={theme.slug + theme.group} href={`/anime/${anime.slug}/${videoSlug}`} passHref prefetch={false}>
                     <Button as="a">
                         <Button as="span" variant="primary" isCircle>
                             <Icon icon={faPlay}/>
@@ -149,7 +149,7 @@ function ThemesTable({ anime, group = null }) {
             const videoSlug = createVideoSlug(theme, entry, video);
 
             return (
-                <Link key={theme.slug + theme.group} href={`/anime/${anime.slug}/${videoSlug}`} passHref>
+                <Link key={theme.slug + theme.group} href={`/anime/${anime.slug}/${videoSlug}`} passHref prefetch={false}>
                     <StyledThemeRow>
                         {!videoIndex ? (
                             entry.version > 1 ? (

--- a/src/components/card/SummaryCard.js
+++ b/src/components/card/SummaryCard.js
@@ -47,7 +47,7 @@ export function SummaryCard({ title, description, image, to, children, ...props 
 
     return (
         <StyledSummaryCard {...props}>
-            <Link href={to}>
+            <Link href={to} prefetch={false}>
                 <a>
                     <StyledCover
                         alt="Cover"
@@ -61,7 +61,7 @@ export function SummaryCard({ title, description, image, to, children, ...props 
             <StyledBody>
                 <Text maxLines={1} title={typeof title === "string" && title}>
                     {typeof title === "string" ? (
-                        <Link href={to} passHref>
+                        <Link href={to} passHref prefetch={false}>
                             <Text as="a" link>{title}</Text>
                         </Link>
                     ) : title}

--- a/src/components/card/ThemeSummaryCard.js
+++ b/src/components/card/ThemeSummaryCard.js
@@ -29,7 +29,7 @@ export function ThemeSummaryCard({ theme, artist, children, ...props }) {
         <SummaryCard.Description>
             <span>Theme</span>
             <span>{theme.type}{theme.sequence || null}{theme.group && ` (${theme.group})`}</span>
-            <Link href={`/anime/${theme.anime.slug}`} passHref>
+            <Link href={`/anime/${theme.anime.slug}`} passHref prefetch={false}>
                 <Text as="a" link>{theme.anime.name}</Text>
             </Link>
         </SummaryCard.Description>

--- a/src/components/index/AlphabeticalIndex.js
+++ b/src/components/index/AlphabeticalIndex.js
@@ -37,7 +37,7 @@ export function AlphabeticalIndex({ items, children }) {
         <>
             <StyledLetterList>
                 {itemsByFirstLetter.map(([ firstLetter ]) => (
-                    <Link key={firstLetter} href={`#${firstLetter}`} passHref>
+                    <Link key={firstLetter} href={`#${firstLetter}`} passHref prefetch={false}>
                         <Text as="a" link>{firstLetter.toUpperCase()} </Text>
                     </Link>
                 ))}

--- a/src/components/navigation/Navigation.js
+++ b/src/components/navigation/Navigation.js
@@ -47,13 +47,13 @@ export function Navigation({ offsetToggleButton = false }) {
         <>
             <StyledNavigation show={show} onClick={() => setShow(false)}>
                 <StyledNavigationContainer onClick={(event) => event.stopPropagation()}>
-                    <Link href="/" passHref>
+                    <Link href="/" passHref prefetch={false}>
                         <StyledLogoContainer>
                             <StyledLogo width="277" height="150"/>
                         </StyledLogoContainer>
                     </Link>
                     <StyledNavigationLinks>
-                        <Link href="/search" passHref>
+                        <Link href="/search" passHref prefetch={false}>
                             <Button as="a" variant="silent" style={{ "--gap": "8px" }}>
                                 <Icon icon={faSearch}/>
                                 <Text>Search</Text>
@@ -63,13 +63,13 @@ export function Navigation({ offsetToggleButton = false }) {
                             <Icon icon={faRandom}/>
                             <Text>Play Random</Text>
                         </Button>
-                        <Link href={(currentYear && currentSeason) ? `/year/${currentYear}/${currentSeason}` : "/"} passHref>
+                        <Link href={(currentYear && currentSeason) ? `/year/${currentYear}/${currentSeason}` : "/"} passHref prefetch={false}>
                             <Button as="a" variant="silent" style={{ "--gap": "8px" }}>
                                 <Icon icon={faTv}/>
                                 <Text>Current Season</Text>
                             </Button>
                         </Link>
-                        <Link href="/profile" passHref>
+                        <Link href="/profile" passHref prefetch={false}>
                             <StyledCollapsibleLink forwardedAs="a" title="My Profile">
                                 <Icon icon={faUser}/>
                                 <span>My Profile</span>

--- a/src/components/navigation/SearchNavigation.js
+++ b/src/components/navigation/SearchNavigation.js
@@ -80,11 +80,11 @@ export function SearchNavigation() {
                 />
                 <HorizontalScroll fixShadows>
                     <Switcher selectedItem={entity || null}>
-                        <Link href={{ pathname: "/search", query: urlParams }} passHref>
+                        <Link href={{ pathname: "/search", query: urlParams }} passHref prefetch={false}>
                             <Switcher.Reset as="a"/>
                         </Link>
                         {[ "anime", "theme", "artist", "series", "studio" ].map((entity) => (
-                            <Link key={entity} href={{ pathname: `/search/${entity}`, query: urlParams }} passHref>
+                            <Link key={entity} href={{ pathname: `/search/${entity}`, query: urlParams }} passHref prefetch={false}>
                                 <Switcher.Option as="a" value={entity}>
                                     {capitalize(entity)}
                                 </Switcher.Option>

--- a/src/components/navigation/SeasonNavigation.js
+++ b/src/components/navigation/SeasonNavigation.js
@@ -9,7 +9,7 @@ export function SeasonNavigation({ year, season, seasonList }) {
             <HorizontalScroll fixShadows>
                 <Switcher items={seasonList.map((s) => s.toLowerCase())} selectedItem={season && season.toLowerCase()}>
                     {seasonList.map((season) => (
-                        <Link key={season} href={`/year/${year}/${season.toLowerCase()}`} passHref>
+                        <Link key={season} href={`/year/${year}/${season.toLowerCase()}`} passHref prefetch={false}>
                             <Switcher.Option as="a" value={season.toLowerCase()}>{season}</Switcher.Option>
                         </Link>
                     ))}

--- a/src/components/navigation/YearNavigation.js
+++ b/src/components/navigation/YearNavigation.js
@@ -26,19 +26,19 @@ export function YearNavigation({ year, yearList }) {
         <Row style={{ "--align-items": "center" }}>
             <StyledYearPrevious>
                 {previousYear && (
-                    <Link href={`/year/${previousYear}`} passHref>
+                    <Link href={`/year/${previousYear}`} passHref prefetch={false}>
                         <Button as="a" variant="silent">{previousYear}</Button>
                     </Link>
                 )}
             </StyledYearPrevious>
-            <Link href={`/year`} passHref>
+            <Link href={`/year`} passHref prefetch={false}>
                 <Button as="a" variant="silent">
                     <Text variant="h1">{year}</Text>
                 </Button>
             </Link>
             <StyledYearNext>
                 {nextYear && (
-                    <Link href={`/year/${nextYear}`} passHref>
+                    <Link href={`/year/${nextYear}`} passHref prefetch={false}>
                         <Button as="a" variant="silent">{nextYear}</Button>
                     </Link>
                 )}

--- a/src/components/search/SearchGlobal.js
+++ b/src/components/search/SearchGlobal.js
@@ -123,7 +123,7 @@ function GlobalSearchSection({ entity, title, results, renderSummaryCard }) {
             </Column>
             {hasMoreResults && (
                 <Row style={{ "--justify-content": "center" }}>
-                    <Link href={{ pathname: `/search/${entity}`, query: urlParams }} passHref>
+                    <Link href={{ pathname: `/search/${entity}`, query: urlParams }} passHref prefetch={false}>
                         <Button as="a" variant="silent" isCircle title="See all results">
                             <Icon icon={faChevronDown}/>
                         </Button>

--- a/src/components/toast/PlaylistAddToast.js
+++ b/src/components/toast/PlaylistAddToast.js
@@ -6,7 +6,7 @@ import { SongTitle } from "components/utils";
 
 export function PlaylistAddToast({ theme }) {
     return (
-        <Link href="/profile/playlist" passHref>
+        <Link href="/profile/playlist" passHref prefetch={false}>
             <Toast as="a" hoverable>
                 <Row wrap style={{ "--justify-content": "space-between", "--gap": "8px" }}>
                     <span><SongTitle song={theme.song}/> was added to the playlist!</span>

--- a/src/components/utils/SongTitle.js
+++ b/src/components/utils/SongTitle.js
@@ -6,7 +6,7 @@ export function SongTitle({ song, songTitleLinkTo }) {
 
     if (songTitleLinkTo) {
         return (
-            <Link href={songTitleLinkTo} passHref>
+            <Link href={songTitleLinkTo} passHref prefetch={false}>
                 <Text as="a" link title={songTitle} italics={!song?.title}>{songTitle}</Text>
             </Link>
         );

--- a/src/components/utils/SongTitleWithArtists.js
+++ b/src/components/utils/SongTitleWithArtists.js
@@ -43,7 +43,7 @@ function Performances({ song, artist }) {
                     <Text variant="small" color="text-muted">
                         <span> as </span>
                         <span>
-                            <Link href={`/artist/${performedAs.artist.slug}`} passHref>
+                            <Link href={`/artist/${performedAs.artist.slug}`} passHref prefetch={false}>
                                 <StyledArtistLink>
                                     {performedAs.as}
                                 </StyledArtistLink>
@@ -57,7 +57,7 @@ function Performances({ song, artist }) {
                         <span>
                             {performedWith.map((performance) => (
                                 <StyledArtist key={performance.artist.slug}>
-                                    <Link href={`/artist/${performance.artist.slug}`} passHref>
+                                    <Link href={`/artist/${performance.artist.slug}`} passHref prefetch={false}>
                                         <StyledArtistLink>
                                             {performance.as || performance.artist.name}
                                         </StyledArtistLink>
@@ -77,7 +77,7 @@ function Performances({ song, artist }) {
             <span>
                 {song.performances.map((performance) => (
                     <StyledArtist key={performance.artist.slug}>
-                        <Link href={`/artist/${performance.artist.slug}`} passHref>
+                        <Link href={`/artist/${performance.artist.slug}`} passHref prefetch={false}>
                             <StyledArtistLink>
                                 {performance.as || performance.artist.name}
                             </StyledArtistLink>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -11,7 +11,7 @@ export default function NotFoundPage() {
                 <span>The page you requested doesn&apos;t exist. If you believe this is an error, message us on </span>
                 <Text as="a" link href="https://discordapp.com/invite/m9zbVyQ">Discord</Text>
                 <span>. Otherwise you can </span>
-                <Link href="/" passHref>
+                <Link href="/" passHref prefetch={false}>
                     <Text as="a" link>go back to the home page</Text>
                 </Link>
                 <span>.</span>

--- a/src/pages/anime/[animeSlug]/[videoSlug]/index.js
+++ b/src/pages/anime/[animeSlug]/[videoSlug]/index.js
@@ -18,6 +18,7 @@ import theme from "theme";
 import createVideoSlug from "utils/createVideoSlug";
 import gql from "graphql-tag";
 import fetchStaticPaths from "utils/fetchStaticPaths";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledVideoInfo = styled.div`
     display: grid;
@@ -160,7 +161,7 @@ export default function VideoPage({ anime, theme, entry, video }) {
                     <SongTitleWithArtists song={theme.song}/>
                     <Text variant="small" color="text-muted" maxLines={1}>
                         <Text>{theme.type}{theme.sequence || null}{theme.group && ` (${theme.group})`} from </Text>
-                        <Link href={`/anime/${anime.slug}`} passHref>
+                        <Link href={`/anime/${anime.slug}`} passHref prefetch={false}>
                             <Text as="a" link>{anime.name}</Text>
                         </Link>
                     </Text>
@@ -378,13 +379,15 @@ export async function getStaticProps({ params: { animeSlug, videoSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             anime,
             theme: pageTheme,
             video: pageVideo,
             entry: pageEntry,
             isVideoPage: true
         },
-        revalidate: 5 * 60
+        // Revalidate after 1 hour (= 3600 seconds).
+        revalidate: 3600
     };
 }
 

--- a/src/pages/anime/[animeSlug]/index.js
+++ b/src/pages/anime/[animeSlug]/index.js
@@ -16,6 +16,7 @@ import useImage from "hooks/useImage";
 import { resourceSiteComparator, seriesNameComparator, studioNameComparator } from "utils/comparators";
 import fetchStaticPaths from "utils/fetchStaticPaths";
 import gql from "graphql-tag";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledList = styled.div`
     display: flex;
@@ -47,7 +48,7 @@ export default function AnimeDetailPage({ anime }) {
                             </DescriptionList.Item>
                         )}
                         <DescriptionList.Item title="Premiere">
-                            <Link href={`/year/${anime.year}${anime.season ? `/${anime.season.toLowerCase()}` : ""}`} passHref>
+                            <Link href={`/year/${anime.year}${anime.season ? `/${anime.season.toLowerCase()}` : ""}`} passHref prefetch={false}>
                                 <Text as="a" link>
                                     {(anime.season ? anime.season + " " : "") + anime.year}
                                 </Text>
@@ -57,7 +58,7 @@ export default function AnimeDetailPage({ anime }) {
                             <DescriptionList.Item title="Series">
                                 <StyledList>
                                     {anime.series.sort(seriesNameComparator).map((series) =>
-                                        <Link key={series.slug} href={`/series/${series.slug}`} passHref>
+                                        <Link key={series.slug} href={`/series/${series.slug}`} passHref prefetch={false}>
                                             <Text as="a" link>
                                                 {series.name}
                                             </Text>
@@ -70,7 +71,7 @@ export default function AnimeDetailPage({ anime }) {
                             <DescriptionList.Item title="Studios">
                                 <StyledList>
                                     {anime.studios.sort(studioNameComparator).map((studio) =>
-                                        <Link key={studio.slug} href={`/studio/${studio.slug}`} passHref>
+                                        <Link key={studio.slug} href={`/studio/${studio.slug}`} passHref prefetch={false}>
                                             <Text as="a" link>
                                                 {studio.name}
                                             </Text>
@@ -207,9 +208,9 @@ export async function getStaticProps({ params: { animeSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             anime: data.anime
-        },
-        revalidate: 5 * 60
+        }
     };
 }
 

--- a/src/pages/anime/index.js
+++ b/src/pages/anime/index.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { fetchData } from "lib/server";
 import { Text } from "components/text";
 import { AlphabeticalIndex } from "components/index";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 export default function AnimeIndexPage({ animeAll }) {
     return (
@@ -33,8 +34,10 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             animeAll: data.animeAll
         },
-        revalidate: 60 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }

--- a/src/pages/api/revalidate.js
+++ b/src/pages/api/revalidate.js
@@ -1,0 +1,84 @@
+import { fetchData } from "lib/server";
+import gql from "graphql-tag";
+import createVideoSlug from "utils/createVideoSlug";
+
+export default async function handler(req, res) {
+    const { secret, id, resource, mode = "page" } = req.query;
+
+    if (secret !== process.env.REVALIDATE_TOKEN) {
+        return res.status(401).json({ message: "Invalid token." });
+    }
+
+    if (!id) {
+        return res.status(400).json({ message: "Invalid id." });
+    }
+
+    const paths = [];
+
+    if (mode === "page") {
+        paths.push(id);
+    } else if (mode === "resource") {
+        if (resource === "anime") {
+            paths.push(...await getAffectedPathsForAnime(id));
+        } else {
+            return res.status(400).json({ message: "Invalid resource." });
+        }
+    } else {
+        return res.status(400).json({ message: "Invalid mode." });
+    }
+
+    for (const path of paths) {
+        await res.unstable_revalidate(path);
+    }
+
+    return res.json({ revalidated: true, affectedPaths: paths });
+}
+
+async function getAffectedPathsForAnime(animeSlug) {
+    const { data } = await fetchData(gql`
+        ${createVideoSlug.fragments.theme}
+        ${createVideoSlug.fragments.entry}
+        ${createVideoSlug.fragments.video}
+        
+        query($animeSlug: String!) {
+            anime(slug: $animeSlug) {
+                year
+                season
+                series {
+                    slug
+                }
+                studios {
+                    slug
+                }
+                themes {
+                    ...createVideoSlug_theme
+                    song {
+                        performances {
+                            artist {
+                                slug
+                            }
+                        }
+                    }
+                    entries {
+                        ...createVideoSlug_entry
+                        videos {
+                            ...createVideoSlug_video
+                        }
+                    }
+                }
+            }
+        }
+    `, { animeSlug });
+
+    return [
+        `/anime/${animeSlug}`,
+        `/year/${data.anime.year}`,
+        `/year/${data.anime.year}/${data.anime.season}`,
+        data.anime.series?.map((series) => `/series/${series.slug}`),
+        data.anime.studio?.map((studio) => `/studio/${studio.slug}`),
+        data.anime.themes?.flatMap((theme) => [
+            theme.song.performances?.flatMap((performance) => `/artist/${performance.artist.slug}`),
+            theme.entries?.flatMap((entry) => entry.videos?.map((video) => `/anime/${animeSlug}/${createVideoSlug(theme, entry, video)}`)),
+        ].flat()),
+    ].flat().filter((e) => e);
+}

--- a/src/pages/artist/[artistSlug]/index.js
+++ b/src/pages/artist/[artistSlug]/index.js
@@ -28,6 +28,7 @@ import { SEO } from "components/seo";
 import useImage from "hooks/useImage";
 import gql from "graphql-tag";
 import fetchStaticPaths from "utils/fetchStaticPaths";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledList = styled.div`
     display: flex;
@@ -94,7 +95,7 @@ export default function ArtistDetailPage({ artist }) {
                             <DescriptionList.Item title="Members">
                                 <StyledList>
                                     {artist.members.map(({ member }) =>
-                                        <Link key={member.slug} href={`/artist/${member.slug}`} passHref>
+                                        <Link key={member.slug} href={`/artist/${member.slug}`} passHref prefetch={false}>
                                             <Text as="a" link>
                                                 {member.name}
                                             </Text>
@@ -107,7 +108,7 @@ export default function ArtistDetailPage({ artist }) {
                             <DescriptionList.Item title="Member of">
                                 <StyledList>
                                     {artist.groups.map(({ group }) =>
-                                        <Link key={group.slug} href={`/artist/${group.slug}`} passHref>
+                                        <Link key={group.slug} href={`/artist/${group.slug}`} passHref prefetch={false}>
                                             <Text as="a" link>
                                                 {group.name}
                                             </Text>
@@ -242,9 +243,11 @@ export async function getStaticProps({ params: { artistSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             artist: data.artist
         },
-        revalidate: 5 * 60
+        // Revalidate after 1 hour (= 3600 seconds).
+        revalidate: 3600
     };
 }
 

--- a/src/pages/artist/index.js
+++ b/src/pages/artist/index.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { fetchData } from "lib/server";
 import { Text } from "components/text";
 import { AlphabeticalIndex } from "components/index";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 export default function ArtistIndexPage({ artistAll }) {
     return (
@@ -33,8 +34,10 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             artistAll: data.artistAll
         },
-        revalidate: 60 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }

--- a/src/pages/design.js
+++ b/src/pages/design.js
@@ -34,6 +34,7 @@ import { Toast } from "components/toast";
 import { useToasts } from "context/toastContext";
 import { Input } from "components/input";
 import gql from "graphql-tag";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const ColorGrid = styled.div`
     display: grid;
@@ -651,6 +652,7 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             demoData: data
         }
     };

--- a/src/pages/dev.js
+++ b/src/pages/dev.js
@@ -4,14 +4,13 @@ import { Text } from "components/text";
 import styled from "styled-components";
 import { Column } from "components/box";
 import { ExternalLink } from "components/external-link";
-import { fetchData } from "lib/server";
 import theme from "theme";
 
 const StyledLink = styled.a`
     max-width: 100%;
 `;
 
-export default function DevelopmentPage({ counter }) {
+export default function DevelopmentPage() {
     return (
         <>
             <Text variant="h1">Development Hub</Text>
@@ -70,33 +69,18 @@ export default function DevelopmentPage({ counter }) {
                 />
                 <PageGridItem
                     path="/year/2009"
-                    description={(
-                        <Text>
-                            Browse all seasons of a specific year.
-                            <Text color="text-disabled"> ({ counter.year } pages)</Text>
-                        </Text>
-                    )}
+                    description="Browse all seasons of a specific year."
                     otherPaths={{
                         "/year/1963": "Every year has a page, even 60s, 70s, etc."
                     }}
                 />
                 <PageGridItem
                     path="/year/2009/summer"
-                    description={(
-                        <Text>
-                            Browse all anime of a specific season.
-                            <Text color="text-disabled"> ({ counter.season } pages)</Text>
-                        </Text>
-                    )}
+                    description="Browse all anime of a specific season."
                 />
                 <PageGridItem
                     path="/series/monogatari"
-                    description={(
-                        <Text>
-                            Browse all anime which belong to the same series.
-                            <Text color="text-disabled"> ({ counter.series } pages)</Text>
-                        </Text>
-                    )}
+                    description="Browse all anime which belong to the same series."
                     otherPaths={{
                         "/series/precure": "A lot of anime.",
                         "/series/clannad": "Only three anime.",
@@ -105,33 +89,18 @@ export default function DevelopmentPage({ counter }) {
                 />
                 <PageGridItem
                     path="/studio/kyoto_animation"
-                    description={
-                        <Text>
-                            Browse all anime which were produced by the same studio.
-                            <Text color="text-disabled"> ({ counter.studio } pages)</Text>
-                        </Text>
-                    }
+                    description="Browse all anime which were produced by the same studio."
                 />
                 <PageGridItem
                     path="/artist/kana_hanazawa"
-                    description={(
-                        <Text>
-                            Browse all songs an artist has performed.
-                            <Text color="text-disabled"> ({ counter.artist } pages)</Text>
-                        </Text>
-                    )}
+                    description="Browse all songs an artist has performed."
                     otherPaths={{
                         "/artist/vickeblanka": "Very few songs."
                     }}
                 />
                 <PageGridItem
                     path="/anime/bakemonogatari"
-                    description={(
-                        <Text>
-                            Browse all themes of a specific anime.
-                            <Text color="text-disabled"> ({ counter.anime } pages)</Text>
-                        </Text>
-                    )}
+                    description="Browse all themes of a specific anime."
                     otherPaths={{
                         "/anime/etotama": "Many themes with a lot of artists.",
                         "/anime/gintama": "Theme groups with many themes.",
@@ -142,12 +111,7 @@ export default function DevelopmentPage({ counter }) {
                 />
                 <PageGridItem
                     path="/anime/bakemonogatari/OP1-NCBD1080"
-                    description={(
-                        <Text>
-                            Watch themes.
-                            <Text color="text-disabled"> ({ counter.video } pages)</Text>
-                        </Text>
-                    )}
+                    description="Watch themes."
                     otherPaths={{
                         "/anime/uma_musume_pretty_derby/ED5": "Many artists.",
                         "/anime/girls_und_panzer/ED-NCBD1080": "Many alternative versions.",
@@ -217,7 +181,7 @@ function PageGridItem({ path, otherPaths = {}, description }) {
 
 function PageLink({ path }) {
     return (
-        <Link key={path} href={path} passHref>
+        <Link key={path} href={path} passHref prefetch={false}>
             <StyledLink to={path}>
                 <Text variant="code" link maxLines={1}>{path}</Text>
             </StyledLink>
@@ -233,29 +197,4 @@ function TagNew() {
     return (
         <StyledTagNew>NEW: </StyledTagNew>
     );
-}
-
-export async function getStaticProps() {
-    const { data } = await fetchData(`
-        #graphql
-
-        query {
-            counter {
-                anime
-                artist
-                series
-                studio
-                video
-                year
-                season
-            }
-        }
-    `);
-
-    return {
-        props: {
-            counter: data.counter
-        },
-        revalidate: 60
-    };
 }

--- a/src/pages/event/[bracketSlug]/index.js
+++ b/src/pages/event/[bracketSlug]/index.js
@@ -13,6 +13,7 @@ import { SongTitleWithArtists } from "components/utils";
 import { useState } from "react";
 import { Switcher } from "components/switcher";
 import { fetchData } from "lib/server";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const CornerIcon = styled(Icon).attrs({
     size: "2x"
@@ -190,7 +191,7 @@ function ThemeSummaryCard({ theme, isVoted, isWinner, seed, votes, ...props }) {
     const description = (
         <SummaryCard.Description>
             <span>{theme.slug}</span>
-            <Link href={`/anime/${theme.anime.slug}`} passHref>
+            <Link href={`/anime/${theme.anime.slug}`} passHref prefetch={false}>
                 <Text as="a" link>{theme.anime.name}</Text>
             </Link>
         </SummaryCard.Description>
@@ -304,6 +305,7 @@ export async function getStaticProps({ params: { bracketSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             bracket: data.bracket
         }
     };

--- a/src/pages/event/anime-awards.js
+++ b/src/pages/event/anime-awards.js
@@ -14,6 +14,7 @@ import { SongTitleWithArtists } from "components/utils";
 import { Icon } from "components/icon";
 import { faAward, faHashtag, faUsers } from "@fortawesome/free-solid-svg-icons";
 import { motion } from "framer-motion";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledHeader = styled.div`
     display: flex;
@@ -164,7 +165,7 @@ function ThemeSummaryCard({ theme, rank, votes, ...props }) {
     const description = (
         <SummaryCard.Description>
             <span>{theme.slug}</span>
-            <Link href={`/anime/${theme.anime.slug}`} passHref>
+            <Link href={`/anime/${theme.anime.slug}`} passHref prefetch={false}>
                 <Text as="a" link>{theme.anime.name}</Text>
             </Link>
         </SummaryCard.Description>
@@ -218,6 +219,7 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             awards
         }
     };

--- a/src/pages/event/index.js
+++ b/src/pages/event/index.js
@@ -8,6 +8,7 @@ import { fetchData } from "lib/server";
 import { faArrowRight, faAward, faTrophy } from "@fortawesome/free-solid-svg-icons";
 import { Icon } from "components/icon";
 import theme from "theme";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const BigButton = styled(Button)`
     overflow: hidden;
@@ -41,7 +42,7 @@ export default function EventPage({ awards, brackets }) {
                 <Column style={{ "--gap": "16px" }}>
                     <Text variant="h2">Awards</Text>
                     {awards.map(({ name, path }) => (
-                        <Link key={path} href={path} passHref>
+                        <Link key={path} href={path} passHref prefetch={false}>
                             <BigButton forwardedAs="a">
                                 <BigIcon icon={faAward}/>
                                 <Text>{name}</Text>
@@ -53,7 +54,7 @@ export default function EventPage({ awards, brackets }) {
                 <Column style={{ "--gap": "16px" }}>
                     <Text variant="h2">Brackets</Text>
                     {brackets.map(({ name, path }) => (
-                        <Link key={path} href={path} passHref>
+                        <Link key={path} href={path} passHref prefetch={false}>
                             <BigButton forwardedAs="a">
                                 <BigIcon icon={faTrophy}/>
                                 <Text>{name}</Text>
@@ -96,6 +97,7 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             awards,
             brackets
         }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,6 +16,7 @@ import { SEO } from "components/seo";
 import { FeaturedTheme } from "components/featured-theme";
 import gql from "graphql-tag";
 import { fetchDataClient } from "lib/client";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const BigButton = styled(Button)`
     justify-content: flex-end;
@@ -80,8 +81,8 @@ const About = styled(Column)`
     gap: 24px;
 `;
 
-export default function HomePage({ featuredTheme, recentlyAdded: recentlyAddedInitial }) {
-    const [ recentlyAdded, setRecentlyAdded ] = useState(recentlyAddedInitial);
+export default function HomePage({ featuredTheme }) {
+    const [ recentlyAdded, setRecentlyAdded ] = useState([]);
     const { currentYear, currentSeason } = useCurrentSeason();
 
     useEffect(() => {
@@ -121,7 +122,7 @@ export default function HomePage({ featuredTheme, recentlyAdded: recentlyAddedIn
                 </RecentlyAdded>
 
                 <MainGridArea area="c">
-                    <Link href="/search" passHref>
+                    <Link href="/search" passHref prefetch={false}>
                         <BigButton forwardedAs="a">
                             <BigIcon icon={faSearch} flip="horizontal"/>
                             <Text>Search</Text>
@@ -137,7 +138,7 @@ export default function HomePage({ featuredTheme, recentlyAdded: recentlyAddedIn
                     </BigButton>
                 </MainGridArea>
                 <MainGridArea area="e">
-                    <Link href={(currentYear && currentSeason) ? `/year/${currentYear}/${currentSeason}` : "/"} passHref>
+                    <Link href={(currentYear && currentSeason) ? `/year/${currentYear}/${currentSeason}` : "/"} passHref prefetch={false}>
                         <BigButton forwardedAs="a">
                             <BigIcon icon={faTv}/>
                             <Text>Current Season</Text>
@@ -146,7 +147,7 @@ export default function HomePage({ featuredTheme, recentlyAdded: recentlyAddedIn
                     </Link>
                 </MainGridArea>
                 <MainGridArea area="h">
-                    <Link href="/event" passHref>
+                    <Link href="/event" passHref prefetch={false}>
                         <BigButton forwardedAs="a">
                             <BigIcon icon={faAward}/>
                             <Text>Events</Text>
@@ -155,7 +156,7 @@ export default function HomePage({ featuredTheme, recentlyAdded: recentlyAddedIn
                     </Link>
                 </MainGridArea>
                 <MainGridArea area="i">
-                    <Link href="/profile" passHref>
+                    <Link href="/profile" passHref prefetch={false}>
                         <BigButton forwardedAs="a">
                             <BigIcon icon={faUser}/>
                             <Text>My Profile</Text>
@@ -165,37 +166,37 @@ export default function HomePage({ featuredTheme, recentlyAdded: recentlyAddedIn
                 </MainGridArea>
 
                 <SmallButtonGrid>
-                    <Link href="/anime" passHref>
+                    <Link href="/anime" passHref prefetch={false}>
                         <BigButton forwardedAs="a" style={{ "--height": "48px" }}>
                             <Text>Anime Index</Text>
                             <Icon icon={faArrowRight} color="text-primary"/>
                         </BigButton>
                     </Link>
-                    <Link href="/artist" passHref>
+                    <Link href="/artist" passHref prefetch={false}>
                         <BigButton forwardedAs="a" style={{ "--height": "48px" }}>
                             <Text>Artist Index</Text>
                             <Icon icon={faArrowRight} color="text-primary"/>
                         </BigButton>
                     </Link>
-                    <Link href="/year" passHref>
+                    <Link href="/year" passHref prefetch={false}>
                         <BigButton forwardedAs="a" style={{ "--height": "48px" }}>
                             <Text>Year Index</Text>
                             <Icon icon={faArrowRight} color="text-primary"/>
                         </BigButton>
                     </Link>
-                    <Link href="/series" passHref>
+                    <Link href="/series" passHref prefetch={false}>
                         <BigButton forwardedAs="a" style={{ "--height": "48px" }}>
                             <Text>Series Index</Text>
                             <Icon icon={faArrowRight} color="text-primary"/>
                         </BigButton>
                     </Link>
-                    <Link href="/studio" passHref>
+                    <Link href="/studio" passHref prefetch={false}>
                         <BigButton forwardedAs="a" style={{ "--height": "48px" }}>
                             <Text>Studio Index</Text>
                             <Icon icon={faArrowRight} color="text-primary"/>
                         </BigButton>
                     </Link>
-                    <Link href="/page" passHref>
+                    <Link href="/page" passHref prefetch={false}>
                         <BigButton forwardedAs="a" style={{ "--height": "48px" }}>
                             <Text>Page Index</Text>
                             <Icon icon={faArrowRight} color="text-primary"/>
@@ -233,20 +234,16 @@ export async function getStaticProps() {
         ${ThemeSummaryCard.fragments.theme}
         
         query {
-            featuredTheme: theme(id: 11388) {
+            theme(id: 11388) {
                 ...FeaturedTheme_theme
-            }
-            recentlyAdded: themeAll(orderBy: "id", orderDesc: true, limit: 10) {
-                ...ThemeSummaryCard_theme
             }
         }
     `);
 
     return {
         props: {
-            featuredTheme: data.featuredTheme,
-            recentlyAdded: data.recentlyAdded
-        },
-        revalidate: 60
+            ...getSharedPageProps(),
+            featuredTheme: data.theme
+        }
     };
 }

--- a/src/pages/page/[...pageSlug].js
+++ b/src/pages/page/[...pageSlug].js
@@ -12,6 +12,7 @@ import theme from "theme";
 import { SEO } from "components/seo";
 import fetchStaticPaths from "utils/fetchStaticPaths";
 import gql from "graphql-tag";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledGrid = styled.div`
     display: flex;
@@ -170,7 +171,7 @@ export default function DocumentPage({ page }) {
                 a: ({ children, href, ...props }) => {
                     if (href.startsWith("/")) {
                         return (
-                            <Link href={href} passHref>
+                            <Link href={href} passHref prefetch={false}>
                                 <Text as="a" link {...props}>{children}</Text>
                             </Link>
                         );
@@ -258,12 +259,14 @@ export async function getStaticProps({ params: { pageSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             page: {
                 ...data.page,
                 body: markdownToHtml(data.page.body)
             }
         },
-        revalidate: 5 * 60
+        // Revalidate after 1 hour (= 3600 seconds).
+        revalidate: 3600
     };
 }
 

--- a/src/pages/page/index.js
+++ b/src/pages/page/index.js
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { fetchData } from "lib/server";
 import { SEO } from "components/seo";
 import { Text } from "components/text";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 export default function DocumentIndexPage({ pages }) {
     return (
@@ -9,7 +10,7 @@ export default function DocumentIndexPage({ pages }) {
             <SEO title="Pages"/>
             <Text variant="h1">Pages</Text>
             {pages.map((page) => (
-                <Link key={page.slug} href={`/page/${page.slug}`} passHref>
+                <Link key={page.slug} href={`/page/${page.slug}`} passHref prefetch={false}>
                     <Text as="a" link>{page.name}</Text>
                 </Link>
             ))}
@@ -31,8 +32,10 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             pages: data.pageAll
         },
-        revalidate: 5 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }

--- a/src/pages/profile/index.js
+++ b/src/pages/profile/index.js
@@ -10,7 +10,7 @@ import { useLocalPlaylist } from "context/localPlaylistContext";
 import theme from "theme";
 import { SearchFilter, SearchFilterGroup } from "components/search-filter";
 import { Listbox } from "components/listbox";
-import { featuredThemePreviewSetting, showAnnouncementsSetting } from "utils/settings";
+import { devModeSetting, featuredThemePreviewSetting, showAnnouncementsSetting } from "utils/settings";
 import useSetting from "hooks/useSetting";
 
 const StyledProfileGrid = styled.div`
@@ -41,6 +41,7 @@ export default function ProfilePage() {
 
     const [showAnnouncementsSettingValue, setShowAnnouncementsSettingValue] = useSetting(showAnnouncementsSetting);
     const [featuredThemePreviewSettingValue, setFeaturedThemePreviewSettingValue] = useSetting(featuredThemePreviewSetting);
+    const [devModeSettingValue, setDevModeSettingValue] = useSetting(devModeSetting);
 
     return (
         <>
@@ -66,6 +67,14 @@ export default function ProfilePage() {
                             <Text>Featured Theme Preview</Text>
                             <Listbox value={featuredThemePreviewSettingValue} onChange={setFeaturedThemePreviewSettingValue}>
                                 {Object.entries(featuredThemePreviewSetting.values).map(([ value, label ]) => (
+                                    <Listbox.Option key={value} value={value}>{label}</Listbox.Option>
+                                ))}
+                            </Listbox>
+                        </SearchFilter>
+                        <SearchFilter>
+                            <Text>Developer Mode</Text>
+                            <Listbox value={devModeSettingValue} onChange={setDevModeSettingValue}>
+                                {Object.entries(devModeSetting.values).map(([ value, label ]) => (
                                     <Listbox.Option key={value} value={value}>{label}</Listbox.Option>
                                 ))}
                             </Listbox>

--- a/src/pages/series/[seriesSlug]/index.js
+++ b/src/pages/series/[seriesSlug]/index.js
@@ -15,6 +15,7 @@ import theme from "theme";
 import { MultiCoverImage } from "components/image";
 import gql from "graphql-tag";
 import fetchStaticPaths from "utils/fetchStaticPaths";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledDesktopOnly = styled.div`
     gap: 24px;
@@ -117,9 +118,11 @@ export async function getStaticProps({ params: { seriesSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             series: data.series
         },
-        revalidate: 5 * 60
+        // Revalidate after 1 hour (= 3600 seconds).
+        revalidate: 3600
     };
 }
 

--- a/src/pages/series/index.js
+++ b/src/pages/series/index.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { fetchData } from "lib/server";
 import { Text } from "components/text";
 import { AlphabeticalIndex } from "components/index";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 export default function SeriesIndexPage({ seriesAll }) {
     return (
@@ -33,8 +34,10 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             seriesAll: data.seriesAll
         },
-        revalidate: 60 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }

--- a/src/pages/studio/[studioSlug]/index.js
+++ b/src/pages/studio/[studioSlug]/index.js
@@ -24,6 +24,7 @@ import theme from "theme";
 import { MultiCoverImage } from "components/image";
 import gql from "graphql-tag";
 import fetchStaticPaths from "utils/fetchStaticPaths";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledDesktopOnly = styled.div`    
     @media (max-width: ${theme.breakpoints.tabletMax}) {
@@ -151,9 +152,11 @@ export async function getStaticProps({ params: { studioSlug } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             studio: data.studio
         },
-        revalidate: 5 * 60
+        // Revalidate after 1 hour (= 3600 seconds).
+        revalidate: 3600
     };
 }
 

--- a/src/pages/studio/index.js
+++ b/src/pages/studio/index.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { fetchData } from "lib/server";
 import { Text } from "components/text";
 import { AlphabeticalIndex } from "components/index";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 export default function StudioIndexPage({ studioAll }) {
     return (
@@ -33,8 +34,10 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             studioAll: data.studioAll
         },
-        revalidate: 60 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }

--- a/src/pages/year/[year]/[season]/index.js
+++ b/src/pages/year/[year]/[season]/index.js
@@ -5,6 +5,7 @@ import { fetchData } from "lib/server";
 import { SEO } from "components/seo";
 import gql from "graphql-tag";
 import fetchStaticPaths from "utils/fetchStaticPaths";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const seasonOrder = [ "Winter", "Spring", "Summer", "Fall" ];
 
@@ -68,6 +69,7 @@ export async function getStaticProps({ params: { year, season } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             animeAll: data.season.anime,
             year,
             season,
@@ -78,7 +80,8 @@ export async function getStaticProps({ params: { year, season } }) {
                 .map((season) => season.value)
                 .sort((a, b) => seasonOrder.indexOf(a) - seasonOrder.indexOf(b))
         },
-        revalidate: 5 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }
 

--- a/src/pages/year/[year]/index.js
+++ b/src/pages/year/[year]/index.js
@@ -10,6 +10,7 @@ import { SEO } from "components/seo";
 import gql from "graphql-tag";
 import { ANIME_A_Z, getComparator } from "utils/comparators";
 import fetchStaticPaths from "utils/fetchStaticPaths";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const seasonOrder = [ "Winter", "Spring", "Summer", "Fall" ];
 
@@ -34,7 +35,7 @@ function SeasonPreview({ season, year, animeList }) {
                 ))}
             </Column>
             <Row style={{ "--justify-content": "center" }}>
-                <Link href={`/year/${year}/${season.toLowerCase()}`} passHref>
+                <Link href={`/year/${year}/${season.toLowerCase()}`} passHref prefetch={false}>
                     <Button as="a" variant="silent" isCircle>
                         <Icon icon={faChevronDown}/>
                     </Button>
@@ -90,6 +91,7 @@ export async function getStaticProps({ params: { year } }) {
 
     return {
         props: {
+            ...getSharedPageProps(),
             seasons,
             year,
             yearList: data.yearAll
@@ -97,7 +99,8 @@ export async function getStaticProps({ params: { year } }) {
                 .sort((a, b) => a - b),
             seasonList: seasons.map((season) => season.season)
         },
-        revalidate: 5 * 60
+        // Revalidate after 3 hours (= 10800 seconds).
+        revalidate: 10800
     };
 }
 

--- a/src/pages/year/index.js
+++ b/src/pages/year/index.js
@@ -4,6 +4,7 @@ import { Button } from "components/button";
 import { Text } from "components/text";
 import { fetchData } from "lib/server";
 import { SEO } from "components/seo";
+import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledYearPage = styled.div`
     display: grid;
@@ -18,7 +19,7 @@ export default function YearIndexPage({ years }) {
         <StyledYearPage>
             <SEO title="Browse by Year"/>
             {years.map((year) => (
-                <Link key={year} href={`/year/${year}`} passHref>
+                <Link key={year} href={`/year/${year}`} passHref prefetch={false}>
                     <Button as="a">
                         <Text variant="h1">{year}</Text>
                     </Button>
@@ -41,10 +42,10 @@ export async function getStaticProps() {
 
     return {
         props: {
+            ...getSharedPageProps(),
             years: data.yearAll
                 .map((year) => year.value)
                 .sort((a, b) => b - a)
-        },
-        revalidate: 60
+        }
     };
 }

--- a/src/utils/getSharedPageProps.js
+++ b/src/utils/getSharedPageProps.js
@@ -1,0 +1,6 @@
+// This function generates a set of props that should be provided to every single page.
+export default function getSharedPageProps() {
+    return {
+        lastBuildAt: Date.now()
+    };
+}

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -16,3 +16,12 @@ export const featuredThemePreviewSetting = {
         disabled: "Disabled"
     }
 };
+
+export const devModeSetting = {
+    key: "devMode",
+    initialValue: "disabled",
+    values: {
+        disabled: "Disabled",
+        enabled: "Enabled"
+    }
+};


### PR DESCRIPTION
* Disabled prefetching on all links.
* Increased revalidate interval on all pages.
* Disabled revalidation on year index, dev and home page.
* Removed page counts from dev page.
* Recent themes on the home page are now only fetched on the client-side.
* Added dev mode which displays when a page was last built on the bottom of the page.