### PR TITLE
feat: #120 Pages with a sidebar now stay in the two column layout on tablet devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,7 @@
         "rehype-react": "^7.0.4",
         "sass": "^1.43.4",
         "styled-components": "^5.3.3",
-        "unified": "^10.1.2",
-        "use-debounce": "^7.0.0"
+        "unified": "^10.1.2"
       },
       "devDependencies": {
         "eslint": "7.32.0",
@@ -448,11 +447,11 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.7.tgz",
-      "integrity": "sha512-rKxjNogqu1UYAG/y5FOb6lJsmSQbWA+jq4inWjNEVX54VGGE7/WGnmPaqcsyomNOfS3vIRS6NnG+DxiQSqetjg==",
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.10.tgz",
+      "integrity": "sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==",
       "dependencies": {
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0"
       },
       "peerDependencies": {
@@ -460,12 +459,12 @@
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "8.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.7.tgz",
-      "integrity": "sha512-7byr9J6rfMPFPfiR4u65dy20xHATTvbgOY7KYd1sYPnMKKfRZe0tUgpnE+noXcfob7N8s366WaVh7bEoztQMwg==",
+      "version": "8.3.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.10.tgz",
+      "integrity": "sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==",
       "dependencies": {
-        "@graphql-tools/merge": "8.2.7",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/merge": "8.2.10",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       },
@@ -474,9 +473,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.6.tgz",
-      "integrity": "sha512-wjY2ljKLCnnbRrDNPPgPNqCujou0LFSOWcxAjV6DYUlfFWTsAEvlYmsmY4T+K12wI/fnqoJ2bUwIlap1plFDMg==",
+      "version": "8.6.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
+      "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
       "dependencies": {
         "tslib": "~2.3.0"
       },
@@ -4399,17 +4398,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-debounce": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
-      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==",
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -4911,29 +4899,29 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.7.tgz",
-      "integrity": "sha512-rKxjNogqu1UYAG/y5FOb6lJsmSQbWA+jq4inWjNEVX54VGGE7/WGnmPaqcsyomNOfS3vIRS6NnG+DxiQSqetjg==",
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.2.10.tgz",
+      "integrity": "sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==",
       "requires": {
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "8.3.7",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.7.tgz",
-      "integrity": "sha512-7byr9J6rfMPFPfiR4u65dy20xHATTvbgOY7KYd1sYPnMKKfRZe0tUgpnE+noXcfob7N8s366WaVh7bEoztQMwg==",
+      "version": "8.3.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-8.3.10.tgz",
+      "integrity": "sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==",
       "requires": {
-        "@graphql-tools/merge": "8.2.7",
-        "@graphql-tools/utils": "8.6.6",
+        "@graphql-tools/merge": "8.2.10",
+        "@graphql-tools/utils": "8.6.9",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.6.tgz",
-      "integrity": "sha512-wjY2ljKLCnnbRrDNPPgPNqCujou0LFSOWcxAjV6DYUlfFWTsAEvlYmsmY4T+K12wI/fnqoJ2bUwIlap1plFDMg==",
+      "version": "8.6.9",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz",
+      "integrity": "sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==",
       "requires": {
         "tslib": "~2.3.0"
       }
@@ -7742,12 +7730,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "use-debounce": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-7.0.1.tgz",
-      "integrity": "sha512-fOrzIw2wstbAJuv8PC9Vg4XgwyTLEOdq4y/Z3IhVl8DAE4svRcgyEUvrEXu+BMNgMoc3YND6qLT61kkgEKXh7Q==",
-      "requires": {}
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "rehype-react": "^7.0.4",
     "sass": "^1.43.4",
     "styled-components": "^5.3.3",
-    "unified": "^10.1.2",
-    "use-debounce": "^7.0.0"
+    "unified": "^10.1.2"
   },
   "devDependencies": {
     "eslint": "7.32.0",

--- a/src/components/container/SidebarContainer.js
+++ b/src/components/container/SidebarContainer.js
@@ -6,7 +6,7 @@ export const SidebarContainer = styled.div`
     grid-template-columns: 1fr 3fr;
     grid-gap: 32px 24px;
 
-    @media (max-width: ${theme.breakpoints.tabletMax}) {
+    @media (max-width: ${theme.breakpoints.mobileMax}) {
         grid-template-columns: 1fr;
     }
 `;

--- a/src/components/utils/Performances.js
+++ b/src/components/utils/Performances.js
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { Text } from "components/text";
+import styled from "styled-components";
+
+const StyledArtist = styled(Text)`
+    &:not(:first-of-type)::before {
+        content: ", ";
+        font-size: 0.8rem;
+        font-weight: 700;
+    }
+
+    &:not(:first-of-type):last-of-type::before {
+        content: " & ";
+    }
+`;
+
+const StyledArtistLink = styled(Text).attrs({ as: "a", link: true })`
+    font-size: 1rem;
+`;
+
+export function Performances({ song, artist, maxPerformances = 3 }) {
+    if (!song?.performances?.length) {
+        return null;
+    }
+
+    if (maxPerformances === null) {
+        maxPerformances = song.performances.length;
+    }
+
+    const performances = song.performances.sort((a, b) => a.artist.name.localeCompare(b.artist.name));
+    const performancesShown = performances.slice(0, maxPerformances);
+    const performancesHidden = performances.slice(maxPerformances);
+
+    if (artist) {
+        const performedAs = performances.find((performance) => performance.artist.slug === artist.slug);
+        const performedWith = performances.filter((performance) => performance.artist.slug !== artist.slug);
+
+        return (
+            <>
+                {!!performedAs.as && (
+                    <Text variant="small" color="text-muted">
+                        <span> as </span>
+                        <span>
+                            <Link href={`/artist/${performedAs.artist.slug}`} passHref prefetch={false}>
+                                <StyledArtistLink>
+                                    {performedAs.as}
+                                </StyledArtistLink>
+                            </Link>
+                        </span>
+                    </Text>
+                )}
+                {!!performedWith.length && (
+                    <Text variant="small" color="text-muted">
+                        <span> with </span>
+                        <span>
+                            {performedWith.map((performance) => (
+                                <StyledArtist key={performance.artist.slug}>
+                                    <Link href={`/artist/${performance.artist.slug}`} passHref prefetch={false}>
+                                        <StyledArtistLink>
+                                            {performance.as ? `${performance.as} (CV: ${performance.artist.name})` : performance.artist.name}
+                                        </StyledArtistLink>
+                                    </Link>
+                                </StyledArtist>
+                            ))}
+                        </span>
+                    </Text>
+                )}
+            </>
+        );
+    }
+
+    return (
+        <Text color="text-muted">
+            <Text variant="small"> by </Text>
+            <Text>
+                {performancesShown.map((performance) => (
+                    <StyledArtist key={performance.artist.slug}>
+                        <Link href={`/artist/${performance.artist.slug}`} passHref prefetch={false}>
+                            <Text as="a" link>
+                                {performance.as ? `${performance.as} (CV: ${performance.artist.name})` : performance.artist.name}
+                            </Text>
+                        </Link>
+                    </StyledArtist>
+                ))}
+                {!!performancesHidden.length && (
+                    <StyledArtist>{performancesHidden.length} more</StyledArtist>
+                )}
+            </Text>
+        </Text>
+    );
+}

--- a/src/components/utils/SongTitleWithArtists.js
+++ b/src/components/utils/SongTitleWithArtists.js
@@ -1,22 +1,6 @@
-import Link from "next/link";
 import { Text } from "components/text";
-import styled from "styled-components";
 import gql from "graphql-tag";
-import { SongTitle } from "components/utils";
-
-const StyledArtist = styled(Text)`
-    &:not(:first-of-type)::before {
-        content: ", ";
-    }
-
-    &:not(:first-of-type):last-of-type::before {
-        content: " & ";
-    }
-`;
-
-const StyledArtistLink = styled(Text).attrs({ as: "a", link: true })`
-    font-size: 1rem;
-`;
+import { Performances, SongTitle } from "components/utils";
 
 // Specify an artist if you want to display this in an artist context (e.g. artist page)
 export function SongTitleWithArtists({ song, songTitleLinkTo, artist }) {
@@ -24,67 +8,6 @@ export function SongTitleWithArtists({ song, songTitleLinkTo, artist }) {
         <Text>
             <SongTitle song={song} songTitleLinkTo={songTitleLinkTo}/>
             <Performances song={song} artist={artist}/>
-        </Text>
-    );
-}
-
-function Performances({ song, artist }) {
-    if (!song?.performances?.length) {
-        return null;
-    }
-
-    if (artist) {
-        const performedAs = song.performances.find((performance) => performance.artist.slug === artist.slug);
-        const performedWith = song.performances.filter((performance) => performance.artist.slug !== artist.slug);
-
-        return (
-            <>
-                {!!performedAs.as && (
-                    <Text variant="small" color="text-muted">
-                        <span> as </span>
-                        <span>
-                            <Link href={`/artist/${performedAs.artist.slug}`} passHref prefetch={false}>
-                                <StyledArtistLink>
-                                    {performedAs.as}
-                                </StyledArtistLink>
-                            </Link>
-                        </span>
-                    </Text>
-                )}
-                {!!performedWith.length && (
-                    <Text variant="small" color="text-muted">
-                        <span> with </span>
-                        <span>
-                            {performedWith.map((performance) => (
-                                <StyledArtist key={performance.artist.slug}>
-                                    <Link href={`/artist/${performance.artist.slug}`} passHref prefetch={false}>
-                                        <StyledArtistLink>
-                                            {performance.as || performance.artist.name}
-                                        </StyledArtistLink>
-                                    </Link>
-                                </StyledArtist>
-                            ))}
-                        </span>
-                    </Text>
-                )}
-            </>
-        );
-    }
-
-    return (
-        <Text variant="small" color="text-muted">
-            <span> by </span>
-            <span>
-                {song.performances.map((performance) => (
-                    <StyledArtist key={performance.artist.slug}>
-                        <Link href={`/artist/${performance.artist.slug}`} passHref prefetch={false}>
-                            <StyledArtistLink>
-                                {performance.as || performance.artist.name}
-                            </StyledArtistLink>
-                        </Link>
-                    </StyledArtist>
-                ))}
-            </span>
         </Text>
     );
 }

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -7,3 +7,4 @@ export { ThemeEntryTags } from "./ThemeEntryTags";
 export { VideoTags } from "./VideoTags";
 export { HorizontalScroll } from "./HorizontalScroll";
 export { Highlight } from "./Highlight";
+export { Performances } from "./Performances";

--- a/src/components/video-player/VideoPlayer.style.js
+++ b/src/components/video-player/VideoPlayer.style.js
@@ -48,6 +48,7 @@ export const StyledPlayer = styled(motion.div)`
 
 export const StyledVideo = styled.video`
     width: 100%;
+    max-height: calc(100vh - 96px);
     aspect-ratio: 16 / 9;
     outline: none;
     background-color: rgb(0, 0, 0);

--- a/src/lib/common/animethemes/api.js
+++ b/src/lib/common/animethemes/api.js
@@ -159,9 +159,14 @@ export function apiResolver(config) {
 
         devLog.info(path + ": " + url);
 
+        if (!context.apiRequests) {
+            context.apiRequests = 0;
+        }
+
         return await limit(() => (async () => {
             if (!pagination) {
                 const json = await fetchJson(url);
+                context.apiRequests++;
 
                 return transformer(extractor(json, parent, args), parent, args);
             } else {
@@ -170,6 +175,7 @@ export function apiResolver(config) {
                 let nextUrl = `${url}${url.includes("?") ? "&" : "?"}page[size]=100`;
                 while (nextUrl) {
                     const json = await fetchJson(nextUrl);
+                    context.apiRequests++;
                     results.push(...transformer(extractor(json, parent, args), parent, args));
                     devLog.info(`Collecting: ${url}, Got ${results.length}`);
                     nextUrl = json.links.next;

--- a/src/lib/common/animethemes/resolvers.js
+++ b/src/lib/common/animethemes/resolvers.js
@@ -267,6 +267,14 @@ const resolvers = {
             type: "Studio",
             baseInclude: INCLUDES.Studio.resources
         }),
+    },
+    Performance: {
+        artist: apiResolver({
+            field: "artist"
+        }),
+        song: apiResolver({
+            field: "song"
+        }),
     }
 };
 

--- a/src/lib/common/animethemes/type-defs.js
+++ b/src/lib/common/animethemes/type-defs.js
@@ -145,6 +145,7 @@ const typeDefs = `
         id: Int
         link: String!
         site: String!
+        as: String
     }
     
     type Image {

--- a/src/lib/common/index.js
+++ b/src/lib/common/index.js
@@ -1,12 +1,14 @@
 import { graphql, print } from "graphql";
 
 export function buildFetchData(schema) {
-    return async (query, args = {}) => {
-        const result = await graphql(schema, typeof query === "string" ? query : print(query), null, {}, args);
+    return async (query, args = {}, context = {}) => {
+        const result = await graphql(schema, typeof query === "string" ? query : print(query), null, context, args);
 
         if (result.errors) {
             console.error(JSON.stringify(result.errors, null, 2));
         }
+
+        result.apiRequests = context.apiRequests ?? 0;
 
         return result;
     };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -47,7 +47,7 @@ export default function MyApp({ Component, pageProps }) {
     const [colorTheme, toggleColorTheme] = useColorTheme();
     const [devModeSettingValue] = useSetting(devModeSetting);
 
-    const { lastBuildAt, isVideoPage = false, ...videoPageProps } = pageProps;
+    const { lastBuildAt, apiRequests, isVideoPage = false, ...videoPageProps } = pageProps;
     const [ lastVideoPageProps, setLastVideoPageProps ] = useState(() => {
         return isVideoPage ? videoPageProps : null;
     });
@@ -99,7 +99,7 @@ export default function MyApp({ Component, pageProps }) {
                     )}
                     <Component {...pageProps}/>
                     {devModeSettingValue === "enabled" && lastBuildAt && (
-                        <PageRevalidation lastBuildAt={lastBuildAt}/>
+                        <PageRevalidation lastBuildAt={lastBuildAt} apiRequests={apiRequests}/>
                     )}
                 </StyledContainer>
                 <Footer/>
@@ -117,7 +117,7 @@ function MultiContextProvider({ providers = [], children }) {
     ), children);
 }
 
-function PageRevalidation({ lastBuildAt }) {
+function PageRevalidation({ lastBuildAt, apiRequests }) {
     const router = useRouter();
     const [secret] = useSetting(revalidationTokenSetting);
 
@@ -155,6 +155,10 @@ function PageRevalidation({ lastBuildAt }) {
         ? `${minutesSinceLastBuild} minute${minutesSinceLastBuild === 1 ? "" : "s"}`
         : "a few seconds";
 
+    const apiRequestsDescription = apiRequests
+        ? ` using ${apiRequests} API request${apiRequests === 1 ? "" : "s"}`
+        : "";
+
     const canRebuild = !isRevalidating && !!secret;
     const rebuildDescription = isRevalidating
         ? "Rebuild in progress... The page will automatically reload after it's finished."
@@ -165,7 +169,7 @@ function PageRevalidation({ lastBuildAt }) {
 
     return (
         <Text variant="small" color="text-disabled" link={canRebuild} onClick={revalidate}>
-            Page was last built {lastBuildDescription} ago. {rebuildDescription}
+            Page was last built {lastBuildDescription} ago{apiRequestsDescription}. {rebuildDescription}
         </Text>
     );
 }

--- a/src/pages/anime/[animeSlug]/index.js
+++ b/src/pages/anime/[animeSlug]/index.js
@@ -13,7 +13,13 @@ import { AnimeThemeFilter } from "components/filter";
 import { fetchData } from "lib/server";
 import { SEO } from "components/seo";
 import useImage from "hooks/useImage";
-import { resourceSiteComparator, seriesNameComparator, studioNameComparator } from "utils/comparators";
+import {
+    chain,
+    resourceAsComparator,
+    resourceSiteComparator,
+    seriesNameComparator,
+    studioNameComparator
+} from "utils/comparators";
 import fetchStaticPaths from "utils/fetchStaticPaths";
 import gql from "graphql-tag";
 import getSharedPageProps from "utils/getSharedPageProps";
@@ -83,9 +89,9 @@ export default function AnimeDetailPage({ anime }) {
                         {!!anime.resources?.length && (
                             <DescriptionList.Item title="Links">
                                 <StyledList>
-                                    {anime.resources.sort(resourceSiteComparator).map((resource) => (
+                                    {anime.resources.sort(chain(resourceSiteComparator, resourceAsComparator)).map((resource) => (
                                         <ExternalLink key={resource.link} href={resource.link}>
-                                            {resource.site}
+                                            {resource.site}{!!resource.as && ` (${resource.as})`}
                                         </ExternalLink>
                                     ))}
                                 </StyledList>
@@ -124,7 +130,7 @@ export default function AnimeDetailPage({ anime }) {
 }
 
 export async function getStaticProps({ params: { animeSlug } }) {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query($animeSlug: String!) {
@@ -189,6 +195,7 @@ export async function getStaticProps({ params: { animeSlug } }) {
                 resources {
                     link
                     site
+                    as
                 }
                 images {
                     facet
@@ -208,7 +215,7 @@ export async function getStaticProps({ params: { animeSlug } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             anime: data.anime
         },
         // Revalidate after 1 hour (= 3600 seconds).

--- a/src/pages/anime/index.js
+++ b/src/pages/anime/index.js
@@ -21,7 +21,7 @@ export default function AnimeIndexPage({ animeAll }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query {
@@ -34,7 +34,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             animeAll: data.animeAll
         },
         // Revalidate after 3 hours (= 10800 seconds).

--- a/src/pages/artist/index.js
+++ b/src/pages/artist/index.js
@@ -21,7 +21,7 @@ export default function ArtistIndexPage({ artistAll }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query {
@@ -34,7 +34,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             artistAll: data.artistAll
         },
         // Revalidate after 3 hours (= 10800 seconds).

--- a/src/pages/design.js
+++ b/src/pages/design.js
@@ -638,7 +638,7 @@ function Color({ color }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(gql`
+    const { data, apiRequests } = await fetchData(gql`
         ${AnimeSummaryCard.fragments.anime}
         ${AnimeSummaryCard.fragments.previewThemes}
         
@@ -652,7 +652,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             demoData: data
         }
     };

--- a/src/pages/event/[bracketSlug]/index.js
+++ b/src/pages/event/[bracketSlug]/index.js
@@ -226,7 +226,7 @@ function ThemeSummaryCard({ theme, isVoted, isWinner, seed, votes, ...props }) {
 }
 
 export async function getStaticProps({ params: { bracketSlug } }) {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
         
         fragment CharacterFragment on BracketCharacter {
@@ -305,7 +305,7 @@ export async function getStaticProps({ params: { bracketSlug } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             bracket: data.bracket
         }
     };

--- a/src/pages/event/index.js
+++ b/src/pages/event/index.js
@@ -75,11 +75,12 @@ export async function getStaticProps() {
             path: "/event/anime-awards"
         }
     ];
+    let totalApiRequests = 0;
 
     const brackets = await Promise.all([
         "best-anime-opening-ix-salty-arrow"
     ].map(async (bracket) => {
-        const { data } = await fetchData(`
+        const { data, apiRequests } = await fetchData(`
             #graphql
 
             query($bracketSlug: String!) {
@@ -89,6 +90,8 @@ export async function getStaticProps() {
             }
         `, { bracketSlug: bracket });
 
+        totalApiRequests += apiRequests;
+
         return {
             name: data.bracket.name,
             path: `/event/${bracket}`
@@ -97,7 +100,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(totalApiRequests),
             awards,
             brackets
         }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -229,7 +229,7 @@ export default function HomePage({ featuredTheme }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(gql`
+    const { data, apiRequests } = await fetchData(gql`
         ${FeaturedTheme.fragment}
         ${ThemeSummaryCard.fragments.theme}
         
@@ -242,7 +242,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             featuredTheme: data.theme
         }
     };

--- a/src/pages/page/[...pageSlug].js
+++ b/src/pages/page/[...pageSlug].js
@@ -238,7 +238,7 @@ function TableOfContents({ headings }) {
 }
 
 export async function getStaticProps({ params: { pageSlug } }) {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query($pageSlug: String!) {
@@ -259,7 +259,7 @@ export async function getStaticProps({ params: { pageSlug } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             page: {
                 ...data.page,
                 body: markdownToHtml(data.page.body)

--- a/src/pages/page/index.js
+++ b/src/pages/page/index.js
@@ -19,7 +19,7 @@ export default function DocumentIndexPage({ pages }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query {
@@ -32,7 +32,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             pages: data.pageAll
         },
         // Revalidate after 3 hours (= 10800 seconds).

--- a/src/pages/profile/playlist/index.js
+++ b/src/pages/profile/playlist/index.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { Text } from "components/text";
 import { Column, Row } from "components/box";
 import { SidebarContainer } from "components/container";
-import { ThemeSummaryCard } from "components/card";
+import { Card, ThemeSummaryCard } from "components/card";
 import useToggle from "hooks/useToggle";
 import { useState } from "react";
 import { Button, FilterToggleButton } from "components/button";
@@ -23,11 +23,13 @@ import { Reorder } from "framer-motion";
 import { useLocalPlaylist } from "context/localPlaylistContext";
 import theme from "theme";
 import { MultiCoverImage } from "components/image";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+import { Icon } from "components/icon";
 
 const StyledDesktopOnly = styled.div`
     gap: 24px;
     
-    @media (max-width: ${theme.breakpoints.tabletMax}) {
+    @media (max-width: ${theme.breakpoints.mobileMax}) {
         display: none;
     }
 `;
@@ -129,6 +131,16 @@ export default function PlaylistPage() {
                             <Text color="text-warning">{refreshError}</Text>
                         )}
                     </Row>
+                    <Card color="text-warning">
+                        <Text color="text-warning" weight="bold">
+                            <Icon icon={faExclamationCircle}/> Read this before using the local playlist:
+                        </Text>
+                        <Text as="p">
+                            The local playlist is only saved in your browser&apos;s storage.
+                            You can&apos;t share it between devices and it will be deleted if you clear your browser&apos;s storage (e.g. cookies).
+                            We can&apos;t retrieve a deleted playlist for you.
+                        </Text>
+                    </Card>
                     <StyledReorderContainer>
                         <Reorder.Group as="div" axis="y" values={themes} onReorder={setPlaylist}>
                             {themes.map((theme) => (

--- a/src/pages/search/[entity]/index.js
+++ b/src/pages/search/[entity]/index.js
@@ -1,4 +1,3 @@
-import { useDebounce } from "use-debounce";
 import { SearchAnime, SearchArtist, SearchSeries, SearchStudio, SearchTheme } from "components/search";
 import { useRouter } from "next/router";
 import { SEO } from "components/seo";
@@ -7,18 +6,12 @@ import { capitalize } from "lodash-es";
 export default function SearchEntityPage({ entity }) {
     const router = useRouter();
     const urlParams = router.query;
-    const searchQuery = urlParams.q || "";
-
-    const [ debouncedSearchQuery ] = useDebounce(searchQuery, 500);
-
-    if (!router.isReady) {
-        return null;
-    }
+    const searchQuery = urlParams.q;
 
     return (
         <>
             <SEO title={`${searchQuery ? `${searchQuery} - ` : ""}${capitalize(entity)} Index`}/>
-            <Index searchEntity={entity} searchQuery={debouncedSearchQuery}/>
+            <Index searchEntity={entity} searchQuery={searchQuery}/>
         </>
     );
 }

--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -1,4 +1,3 @@
-import { useDebounce } from "use-debounce";
 import { SearchGlobal } from "components/search";
 import { Column, Row } from "components/box";
 import { faCompass, faSearch } from "@fortawesome/free-solid-svg-icons";
@@ -10,19 +9,13 @@ import { SEO } from "components/seo";
 export default function SearchGlobalPage() {
     const router = useRouter();
     const urlParams = router.query;
-    const searchQuery = urlParams.q || "";
-
-    const [ debouncedSearchQuery ] = useDebounce(searchQuery, 500);
-
-    if (!router.isReady) {
-        return null;
-    }
+    const searchQuery = urlParams.q;
 
     return (
         <>
             <SEO title={searchQuery ? `${searchQuery} - Search` : "Search"}/>
-            {debouncedSearchQuery ? (
-                <SearchGlobal searchQuery={debouncedSearchQuery}/>
+            {searchQuery ? (
+                <SearchGlobal searchQuery={searchQuery}/>
             ) : (
                 <Column style={{ "--gap": "16px" }}>
                     <Row style={{ "--gap": "16px" }}>

--- a/src/pages/series/[seriesSlug]/index.js
+++ b/src/pages/series/[seriesSlug]/index.js
@@ -20,7 +20,7 @@ import getSharedPageProps from "utils/getSharedPageProps";
 const StyledDesktopOnly = styled.div`
     gap: 24px;
     
-    @media (max-width: ${theme.breakpoints.tabletMax}) {
+    @media (max-width: ${theme.breakpoints.mobileMax}) {
         display: none;
     }
 `;
@@ -71,7 +71,7 @@ export default function SeriesDetailPage({ series }) {
 }
 
 export async function getStaticProps({ params: { seriesSlug } }) {
-    const { data } = await fetchData(gql`
+    const { data, apiRequests } = await fetchData(gql`
         ${AnimeSummaryCard.fragments.anime}
         ${AnimeSummaryCard.fragments.previewThemes}
         ${AnimeSummaryCard.fragments.expandable}
@@ -118,7 +118,7 @@ export async function getStaticProps({ params: { seriesSlug } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             series: data.series
         },
         // Revalidate after 1 hour (= 3600 seconds).

--- a/src/pages/series/index.js
+++ b/src/pages/series/index.js
@@ -21,7 +21,7 @@ export default function SeriesIndexPage({ seriesAll }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query {
@@ -34,7 +34,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             seriesAll: data.seriesAll
         },
         // Revalidate after 3 hours (= 10800 seconds).

--- a/src/pages/studio/[studioSlug]/index.js
+++ b/src/pages/studio/[studioSlug]/index.js
@@ -12,8 +12,8 @@ import {
     ANIME_A_Z,
     ANIME_NEW_OLD,
     ANIME_OLD_NEW,
-    ANIME_Z_A,
-    getComparator,
+    ANIME_Z_A, chain,
+    getComparator, resourceAsComparator,
     resourceSiteComparator,
 } from "utils/comparators";
 import { fetchData } from "lib/server";
@@ -27,7 +27,7 @@ import fetchStaticPaths from "utils/fetchStaticPaths";
 import getSharedPageProps from "utils/getSharedPageProps";
 
 const StyledDesktopOnly = styled.div`    
-    @media (max-width: ${theme.breakpoints.tabletMax}) {
+    @media (max-width: ${theme.breakpoints.mobileMax}) {
         display: none;
     }
 `;
@@ -61,9 +61,9 @@ export default function StudioDetailPage({ studio }) {
                         {!!studio.resources && !!studio.resources.length && (
                             <DescriptionList.Item title="Links">
                                 <StyledList>
-                                    {studio.resources.sort(resourceSiteComparator).map((resource) => (
+                                    {studio.resources.sort(chain(resourceSiteComparator, resourceAsComparator)).map((resource) => (
                                         <ExternalLink key={resource.link} href={resource.link}>
-                                            {resource.site}
+                                            {resource.site}{!!resource.as && ` (${resource.as})`}
                                         </ExternalLink>
                                     ))}
                                 </StyledList>
@@ -101,7 +101,7 @@ export default function StudioDetailPage({ studio }) {
 }
 
 export async function getStaticProps({ params: { studioSlug } }) {
-    const { data } = await fetchData(gql`
+    const { data, apiRequests } = await fetchData(gql`
         ${AnimeSummaryCard.fragments.anime}
         ${AnimeSummaryCard.fragments.previewThemes}
         ${AnimeSummaryCard.fragments.expandable}
@@ -137,6 +137,7 @@ export async function getStaticProps({ params: { studioSlug } }) {
                 resources {
                     link
                     site
+                    as
                 }
             }
         }
@@ -152,7 +153,7 @@ export async function getStaticProps({ params: { studioSlug } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             studio: data.studio
         },
         // Revalidate after 1 hour (= 3600 seconds).

--- a/src/pages/studio/index.js
+++ b/src/pages/studio/index.js
@@ -21,7 +21,7 @@ export default function StudioIndexPage({ studioAll }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query {
@@ -34,7 +34,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             studioAll: data.studioAll
         },
         // Revalidate after 3 hours (= 10800 seconds).

--- a/src/pages/year/[year]/[season]/index.js
+++ b/src/pages/year/[year]/[season]/index.js
@@ -34,7 +34,7 @@ export default function SeasonDetailPage({ animeAll, year, season }) {
 export async function getStaticProps({ params: { year, season } }) {
     year = +year;
 
-    const { data } = await fetchData(gql`
+    const { data, apiRequests } = await fetchData(gql`
         ${AnimeSummaryCard.fragments.anime}
         ${AnimeSummaryCard.fragments.previewThemes}
         ${AnimeSummaryCard.fragments.expandable}
@@ -69,7 +69,7 @@ export async function getStaticProps({ params: { year, season } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             animeAll: data.season.anime,
             year,
             season,

--- a/src/pages/year/[year]/index.js
+++ b/src/pages/year/[year]/index.js
@@ -48,7 +48,7 @@ function SeasonPreview({ season, year, animeList }) {
 export async function getStaticProps({ params: { year } }) {
     year = +year;
 
-    const { data } = await fetchData(gql`
+    const { data, apiRequests } = await fetchData(gql`
         ${AnimeSummaryCard.fragments.anime}
         ${AnimeSummaryCard.fragments.previewThemes}
         ${AnimeSummaryCard.fragments.expandable}
@@ -91,7 +91,7 @@ export async function getStaticProps({ params: { year } }) {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             seasons,
             year,
             yearList: data.yearAll

--- a/src/pages/year/index.js
+++ b/src/pages/year/index.js
@@ -30,7 +30,7 @@ export default function YearIndexPage({ years }) {
 }
 
 export async function getStaticProps() {
-    const { data } = await fetchData(`
+    const { data, apiRequests } = await fetchData(`
         #graphql
 
         query {
@@ -42,7 +42,7 @@ export async function getStaticProps() {
 
     return {
         props: {
-            ...getSharedPageProps(),
+            ...getSharedPageProps(apiRequests),
             years: data.yearAll
                 .map((year) => year.value)
                 .sort((a, b) => b - a)

--- a/src/utils/comparators.js
+++ b/src/utils/comparators.js
@@ -30,6 +30,7 @@ export const themeIndexComparator = (a, b) => a.sequence - b.sequence;
 export const studioNameComparator = (a, b) => a.name.localeCompare(b.name);
 export const seriesNameComparator = (a, b) => a.name.localeCompare(b.name);
 export const resourceSiteComparator = (a, b) => a.site.localeCompare(b.site);
+export const resourceAsComparator = (a, b) => (!a.as && -1) || (!b.as && 1) || a.as.localeCompare(b.as);
 
 export const UNSORTED = "unsorted";
 
@@ -55,8 +56,8 @@ const comparators = new Map([
     [ ANIME_NEW_OLD, chain(reverse(animePremiereComparator), animeNameComparator) ],
     [ SONG_A_Z, songTitleComparator ],
     [ SONG_Z_A, reverse(songTitleComparator) ],
-    [ SONG_A_Z_ANIME, chain(toAnime(animeNameComparator), songTitleComparator) ],
-    [ SONG_Z_A_ANIME, chain(reverse(toAnime(animeNameComparator)), songTitleComparator) ],
+    [ SONG_A_Z_ANIME, chain(toAnime(animeNameComparator), themeTypeComparator, themeIndexComparator) ],
+    [ SONG_Z_A_ANIME, chain(reverse(toAnime(animeNameComparator)), themeTypeComparator, themeIndexComparator) ],
     [ SONG_OLD_NEW, chain(toAnime(animePremiereComparator), toAnime(animeNameComparator), songTitleComparator) ],
     [ SONG_NEW_OLD, chain(reverse(toAnime(animePremiereComparator)), toAnime(animeNameComparator), songTitleComparator) ]
 ]);

--- a/src/utils/getSharedPageProps.js
+++ b/src/utils/getSharedPageProps.js
@@ -1,6 +1,7 @@
 // This function generates a set of props that should be provided to every single page.
-export default function getSharedPageProps() {
+export default function getSharedPageProps(apiRequests = 0) {
     return {
-        lastBuildAt: Date.now()
+        lastBuildAt: Date.now(),
+        apiRequests
     };
 }


### PR DESCRIPTION
* Improved stability and performance of the search input.
* Changed display of character voices.
* Changed display of title line on video pages.
* Limited number of artists displayed in song titles.
* Fixed video player growing higher than the viewport.
* Added number of API requests used to build a page to dev info.
* Changed default order of themes on artist pages to be by anime.
* Added support for the "as" attribute of external resources.
* Added warning notice to local playlist page.
* Removed use-debounce as we now use the debounce function from lodash.