### PR TITLE
feat: Added table component

### DIFF
--- a/src/components/card/SummaryCard.js
+++ b/src/components/card/SummaryCard.js
@@ -11,6 +11,7 @@ const StyledSummaryCard = styled(Card)`
     display: flex;
     flex-direction: row;
     align-items: center;
+    gap: 16px;
 
     height: 64px;
     padding: 0 1rem 0 0;
@@ -35,8 +36,6 @@ const StyledCover = styled.img.attrs({
 const StyledBody = styled(Column)`
     flex: 1;
     justify-content: center;
-    
-    padding: 0 1rem;
     gap: 0.25rem;
     
     word-break: break-all;

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -60,12 +60,14 @@ const StyledMenuOverlay = styled(MenuPopover)`
     }
 `;
 
-export function Menu({ children }) {
+export function Menu({ button, children }) {
     return (
         <ReachMenu>
-            <Button as={MenuButton} variant="silent" isCircle>
-                <Icon icon={faEllipsisV}/>
-            </Button>
+            {button ? button(MenuButton) : (
+                <Button as={MenuButton} variant="silent" isCircle>
+                    <Icon icon={faEllipsisV}/>
+                </Button>
+            )}
             <StyledMenuOverlay>
                 <StyledMenuItems>
                     {children}

--- a/src/components/search/SearchAnime.js
+++ b/src/components/search/SearchAnime.js
@@ -13,11 +13,15 @@ const initialFilter = {
     firstLetter: null,
     season: null,
     year: null,
-    sortBy: "name"
+    sortBy: null
 };
 
 export function SearchAnime({ searchQuery }) {
     const { updateDataField: updateFilter, data: filter } = useSessionStorage("filter-anime", initialFilter);
+
+    // Use name sort by default if not searching.
+    // If searching and no other sort was selected, use null (= by relevance).
+    const sortBy = searchQuery ? filter.sortBy : (filter.sortBy ?? "name");
 
     const entitySearch = useEntitySearch("anime", searchQuery, {
         filters: {
@@ -25,7 +29,7 @@ export function SearchAnime({ searchQuery }) {
             season: filter.season,
             year: filter.year
         },
-        sortBy: searchQuery ? null : filter.sortBy
+        sortBy
     });
 
     return (
@@ -36,22 +40,19 @@ export function SearchAnime({ searchQuery }) {
                     <SearchFilterFirstLetter value={filter.firstLetter} setValue={updateFilter("firstLetter")}/>
                     <SearchFilterSeason value={filter.season} setValue={updateFilter("season")}/>
                     <SearchFilterYear value={filter.year} setValue={updateFilter("year")}/>
-                    <SearchFilterSortBy value={searchQuery ? null : filter.sortBy} setValue={updateFilter("sortBy")}>
+                    <SearchFilterSortBy value={sortBy} setValue={updateFilter("sortBy")}>
                         {searchQuery ? (
                             <SearchFilterSortBy.Option>Relevance</SearchFilterSortBy.Option>
-                        ) : (
-                            <>
-                                <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="year,season,name">Old ➜ New</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-year,-season,name">New ➜ Old</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
-                            </>
-                        )}
+                        ) : null}
+                        <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="year,season,name">Old ➜ New</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-year,-season,name">New ➜ Old</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
                     </SearchFilterSortBy>
                 </>
             }
-            renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>}
+            renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime} expandable/>}
             {...entitySearch}
         />
     );

--- a/src/components/search/SearchArtist.js
+++ b/src/components/search/SearchArtist.js
@@ -6,17 +6,21 @@ import useSessionStorage from "hooks/useSessionStorage";
 
 const initialFilter = {
     firstLetter: null,
-    sortBy: "name"
+    sortBy: null
 };
 
 export function SearchArtist({ searchQuery }) {
     const { updateDataField: updateFilter, data: filter } = useSessionStorage("filter-artist", initialFilter);
 
+    // Use name sort by default if not searching.
+    // If searching and no other sort was selected, use null (= by relevance).
+    const sortBy = searchQuery ? filter.sortBy : (filter.sortBy ?? "name");
+
     const entitySearch = useEntitySearch("artist", searchQuery, {
         filters: {
             "name-like": filter.firstLetter ? `${filter.firstLetter}%` : null,
         },
-        sortBy: searchQuery ? null : filter.sortBy
+        sortBy
     });
 
     return (
@@ -25,16 +29,13 @@ export function SearchArtist({ searchQuery }) {
             filters={
                 <>
                     <SearchFilterFirstLetter value={filter.firstLetter} setValue={updateFilter("firstLetter")}/>
-                    <SearchFilterSortBy value={searchQuery ? null : filter.sortBy} setValue={updateFilter("sortBy")}>
+                    <SearchFilterSortBy value={sortBy} setValue={updateFilter("sortBy")}>
                         {searchQuery ? (
                             <SearchFilterSortBy.Option>Relevance</SearchFilterSortBy.Option>
-                        ) : (
-                            <>
-                                <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
-                            </>
-                        )}
+                        ) : null}
+                        <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
                     </SearchFilterSortBy>
                 </>
             }

--- a/src/components/search/SearchGlobal.js
+++ b/src/components/search/SearchGlobal.js
@@ -68,7 +68,7 @@ export function SearchGlobal({ searchQuery }) {
                 entity="anime"
                 title="Anime"
                 results={animeResults}
-                renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>}
+                renderSummaryCard={(anime) => <AnimeSummaryCard key={anime.slug} anime={anime} expandable/>}
             />
             <GlobalSearchSection
                 entity="theme"

--- a/src/components/search/SearchSeries.js
+++ b/src/components/search/SearchSeries.js
@@ -6,17 +6,21 @@ import useSessionStorage from "hooks/useSessionStorage";
 
 const initialFilter = {
     firstLetter: null,
-    sortBy: "name"
+    sortBy: null
 };
 
 export function SearchSeries({ searchQuery }) {
     const { updateDataField: updateFilter, data: filter } = useSessionStorage("filter-series", initialFilter);
 
+    // Use name sort by default if not searching.
+    // If searching and no other sort was selected, use null (= by relevance).
+    const sortBy = searchQuery ? filter.sortBy : (filter.sortBy ?? "name");
+
     const entitySearch = useEntitySearch("series", searchQuery, {
         filters: {
             "name-like": filter.firstLetter ? `${filter.firstLetter}%` : null,
         },
-        sortBy: searchQuery ? null : filter.sortBy
+        sortBy
     });
 
     return (
@@ -25,16 +29,13 @@ export function SearchSeries({ searchQuery }) {
             filters={
                 <>
                     <SearchFilterFirstLetter value={filter.firstLetter} setValue={updateFilter("firstLetter")}/>
-                    <SearchFilterSortBy value={searchQuery ? null : filter.sortBy} setValue={updateFilter("sortBy")}>
+                    <SearchFilterSortBy value={sortBy} setValue={updateFilter("sortBy")}>
                         {searchQuery ? (
                             <SearchFilterSortBy.Option>Relevance</SearchFilterSortBy.Option>
-                        ) : (
-                            <>
-                                <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
-                            </>
-                        )}
+                        ) : null}
+                        <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
                     </SearchFilterSortBy>
                 </>
             }

--- a/src/components/search/SearchStudio.js
+++ b/src/components/search/SearchStudio.js
@@ -6,17 +6,21 @@ import useSessionStorage from "hooks/useSessionStorage";
 
 const initialFilter = {
     firstLetter: null,
-    sortBy: "name"
+    sortBy: null
 };
 
 export function SearchStudio({ searchQuery }) {
     const { updateDataField: updateFilter, data: filter } = useSessionStorage("filter-studio", initialFilter);
 
+    // Use name sort by default if not searching.
+    // If searching and no other sort was selected, use null (= by relevance).
+    const sortBy = searchQuery ? filter.sortBy : (filter.sortBy ?? "name");
+
     const entitySearch = useEntitySearch("studio", searchQuery, {
         filters: {
             "name-like": filter.firstLetter ? `${filter.firstLetter}%` : null,
         },
-        sortBy: searchQuery ? null : filter.sortBy
+        sortBy
     });
 
     return (
@@ -25,16 +29,13 @@ export function SearchStudio({ searchQuery }) {
             filters={
                 <>
                     <SearchFilterFirstLetter value={filter.firstLetter} setValue={updateFilter("firstLetter")}/>
-                    <SearchFilterSortBy value={searchQuery ? null : filter.sortBy} setValue={updateFilter("sortBy")}>
+                    <SearchFilterSortBy value={sortBy} setValue={updateFilter("sortBy")}>
                         {searchQuery ? (
                             <SearchFilterSortBy.Option>Relevance</SearchFilterSortBy.Option>
-                        ) : (
-                            <>
-                                <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
-                            </>
-                        )}
+                        ) : null}
+                        <SearchFilterSortBy.Option value="name">A ➜ Z</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-name">Z ➜ A</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
                     </SearchFilterSortBy>
                 </>
             }

--- a/src/components/search/SearchTheme.js
+++ b/src/components/search/SearchTheme.js
@@ -7,11 +7,15 @@ import useSessionStorage from "hooks/useSessionStorage";
 const initialFilter = {
     firstLetter: null,
     type: null,
-    sortBy: "song.title"
+    sortBy: null
 };
 
 export function SearchTheme({ searchQuery }) {
     const { updateDataField: updateFilter, data: filter } = useSessionStorage("filter-theme", initialFilter);
+
+    // Use song.title sort by default if not searching.
+    // If searching and no other sort was selected, use null (= by relevance).
+    const sortBy = searchQuery ? filter.sortBy : (filter.sortBy ?? "song.title");
 
     const entitySearch = useEntitySearch("theme", searchQuery, {
         filters: {
@@ -19,7 +23,7 @@ export function SearchTheme({ searchQuery }) {
             "song][title-like": filter.firstLetter ? `${filter.firstLetter}%` : null,
             type: filter.type
         },
-        sortBy: searchQuery ? null : filter.sortBy
+        sortBy
     });
 
     return (
@@ -29,18 +33,15 @@ export function SearchTheme({ searchQuery }) {
                 <>
                     <SearchFilterFirstLetter value={filter.firstLetter} setValue={updateFilter("firstLetter")}/>
                     <SearchFilterThemeType value={filter.type} setValue={updateFilter("type")}/>
-                    <SearchFilterSortBy value={searchQuery ? null : filter.sortBy} setValue={updateFilter("sortBy")}>
+                    <SearchFilterSortBy value={sortBy} setValue={updateFilter("sortBy")}>
                         {searchQuery ? (
                             <SearchFilterSortBy.Option>Relevance</SearchFilterSortBy.Option>
-                        ) : (
-                            <>
-                                <SearchFilterSortBy.Option value="song.title">A ➜ Z</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-song.title">Z ➜ A</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="anime.year,anime.season,song.title">Old ➜ New</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-anime.year,-anime.season,song.title">New ➜ Old</SearchFilterSortBy.Option>
-                                <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
-                            </>
-                        )}
+                        ) : null}
+                        <SearchFilterSortBy.Option value="song.title">A ➜ Z</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-song.title">Z ➜ A</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="anime.year,anime.season,song.title">Old ➜ New</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-anime.year,-anime.season,song.title">New ➜ Old</SearchFilterSortBy.Option>
+                        <SearchFilterSortBy.Option value="-created_at">Last Added</SearchFilterSortBy.Option>
                     </SearchFilterSortBy>
                 </>
             }

--- a/src/components/switcher/Switcher.js
+++ b/src/components/switcher/Switcher.js
@@ -1,10 +1,11 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { LayoutGroup, motion } from "framer-motion";
 import theme from "theme";
 import { uniqueId as createUniqueId } from "lodash-es";
 import { createContext, forwardRef, useContext, useMemo } from "react";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { Icon } from "components/icon";
+import { withHover } from "styles/mixins";
 
 const SwitcherContext = createContext();
 
@@ -19,9 +20,7 @@ const StyledSwitcher = styled.div`
     background-color: ${theme.colors["solid"]};
     box-shadow: ${theme.shadows.low};
 `;
-const StyledButton = styled.button`
-    --color: ${theme.colors["text-muted"]};
-    
+const StyledButton = styled.button`    
     position: relative;
     
     display: inline-flex;
@@ -36,9 +35,14 @@ const StyledButton = styled.button`
     text-transform: uppercase;
     letter-spacing: 0.1rem;
     cursor: pointer;
-    color: var(--color);
+    color: ${(props) => props.isSelected ? theme.colors["text-on-primary"] : theme.colors["text-muted"]};
     
     transition: color 500ms;
+
+    ${withHover(css`
+        color: ${(props) => props.isSelected ? theme.colors["text-on-primary"] : theme.colors["text"]};;
+        transition-duration: 250ms;
+    `)}
 `;
 const StyledButtonBackground = styled(motion.div)`
     position: absolute;
@@ -76,9 +80,9 @@ Switcher.Option = forwardRef(function SwitcherItem({ children, value, ...props }
 
     return (
         <StyledButton
-            style={{ "--color": isSelected && theme.colors["text-on-primary"] }}
-            onClick={() => context.select(value)}
             ref={ref}
+            isSelected={isSelected}
+            onClick={() => context.select(value)}
             {...props}
         >
             {isSelected && (

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -1,0 +1,47 @@
+import styled, { css } from "styled-components";
+import theme from "theme";
+import { withHover } from "styles/mixins";
+
+export const Table = styled.div``;
+
+Table.Body = styled.div`
+    border: 2px solid ${theme.colors["solid-on-card"]};
+    border-radius: 8px;
+    overflow: hidden;
+`;
+
+Table.Row = styled.div`
+    display: grid;
+    grid-template-columns: var(--columns);
+    grid-gap: 16px;
+    align-items: baseline;
+    padding: 8px;
+    
+    &:not(:last-of-type) {
+        border-bottom: 2px solid ${theme.colors["solid-on-card"]};
+    }
+    
+    ${withHover(css`
+        background-color: ${theme.colors["solid"]};
+    `)}
+`;
+
+Table.Cell = styled.div`
+    overflow: hidden;
+`;
+
+Table.Head = styled.div`
+    display: grid;
+    grid-template-columns: var(--columns);
+    grid-gap: 16px;
+    align-items: self-end;
+    padding: 8px 10px;
+`;
+
+Table.HeadCell = styled.span`
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: ${theme.colors["text-muted"]};
+`;

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -1,0 +1,1 @@
+export { Table } from "./Table";

--- a/src/components/tag/ContentWarningTags.js
+++ b/src/components/tag/ContentWarningTags.js
@@ -1,0 +1,20 @@
+import { faBomb, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { Tag } from "components/tag";
+import { Icon } from "components/icon";
+
+export function ContentWarningTags({ entry }) {
+    return (
+        <>
+            {!!entry.spoiler && (
+                <Tag icon={<Icon icon={faBomb} color="text-warning"/>}>
+                    SPOILER
+                </Tag>
+            )}
+            {!!entry.nsfw && (
+                <Tag icon={<Icon icon={faExclamationTriangle} color="text-warning"/>}>
+                    NSFW
+                </Tag>
+            )}
+        </>
+    );
+}

--- a/src/components/tag/EpisodeTag.js
+++ b/src/components/tag/EpisodeTag.js
@@ -1,0 +1,10 @@
+import { faFilm } from "@fortawesome/free-solid-svg-icons";
+import { Tag } from "components/tag";
+
+export function EpisodeTag({ entry }) {
+    return (
+        <Tag icon={faFilm}>
+            {entry.episodes || "—"}
+        </Tag>
+    );
+}

--- a/src/components/tag/index.js
+++ b/src/components/tag/index.js
@@ -1,1 +1,3 @@
 export { Tag } from "./Tag";
+export { EpisodeTag } from "./EpisodeTag";
+export { ContentWarningTags } from "./ContentWarningTags";

--- a/src/components/toast/AnnouncementToast.js
+++ b/src/components/toast/AnnouncementToast.js
@@ -3,9 +3,10 @@ import styled from "styled-components";
 import { Toast } from "components/toast";
 import { Text } from "components/text";
 import { fetchAnnouncements } from "lib/client/announcement";
-import { showAnnouncementsSetting } from "utils/settings";
+import { ShowAnnouncements } from "utils/settings";
 import theme from "theme";
 import { useToasts } from "context/toastContext";
+import useSetting from "hooks/useSetting";
 
 const StyledBody = styled.div`
     display: flex;
@@ -23,13 +24,22 @@ const StyledAnnouncements = styled.div`
 export function AnnouncementToast() {
     const { closeToast } = useToasts();
     const [ announcements, setAnnouncements ] = useState([]);
+    const [ showAnnouncements ] = useSetting(ShowAnnouncements);
 
     useEffect(() => {
-        if (window.localStorage.getItem(showAnnouncementsSetting.key) !== "disabled") {
+        let cancelled = false;
+
+        if (showAnnouncements !== ShowAnnouncements.DISABLED) {
             fetchAnnouncements()
-                .then(setAnnouncements);
+                .then((announcements) => {
+                    if (!cancelled) {
+                        setAnnouncements(announcements);
+                    }
+                });
         }
-    }, []);
+
+        return () => { cancelled = true; };
+    }, [showAnnouncements]);
 
     if (!announcements.length) {
         return null;

--- a/src/components/utils/HorizontalScroll.js
+++ b/src/components/utils/HorizontalScroll.js
@@ -9,6 +9,10 @@ export const HorizontalScroll = styled.div`
     padding-left: 1rem;
     padding-right: 1rem;
     
+    & > * {
+        min-width: max-content;
+    }
+    
     ${(props) => !!props.fixShadows && css`
         margin-top: -1rem;
         margin-bottom: -1rem;

--- a/src/components/video-player/VideoPlayer.js
+++ b/src/components/video-player/VideoPlayer.js
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import {
     StyledOverlay,
     StyledPlayer,
@@ -23,6 +23,8 @@ import { videoBaseUrl } from "lib/client/api";
 import useMediaQuery from "hooks/useMediaQuery";
 import styledTheme from "theme";
 import { SongTitle } from "components/utils";
+import useSetting from "hooks/useSetting";
+import { GlobalVolume } from "utils/settings";
 
 export function VideoPlayer({ anime, theme, entry, video, background, ...props }) {
     const [isPlaying, setPlaying] = useState(false);
@@ -33,6 +35,9 @@ export function VideoPlayer({ anime, theme, entry, video, background, ...props }
     const isMobile = useMediaQuery(`(max-width: ${styledTheme.breakpoints.mobileMax})`);
     const videoUrl = `${videoBaseUrl}/video/${video.basename}`;
     const router = useRouter();
+    const [globalVolume, setGlobalVolume] = useSetting(GlobalVolume);
+
+    useEffect(() => playerRef.current.volume = globalVolume, [globalVolume]);
 
     function togglePlay() {
         if (isPlaying) {
@@ -115,6 +120,7 @@ export function VideoPlayer({ anime, theme, entry, video, background, ...props }
                 onEnded={() => setPlaying(false)}
                 onClick={background && isMobile ? maximize : undefined}
                 onTimeUpdate={updateProgress}
+                onVolumeChange={(event) => setGlobalVolume(event.target.volume)}
             />
             {background && (
                 <>

--- a/src/hooks/useSetting.js
+++ b/src/hooks/useSetting.js
@@ -1,13 +1,21 @@
 import { useEffect, useState } from "react";
 
-export default function useSetting({ key, initialValue }) {
+export default function useSetting({ __KEY__: key, __INITIAL_VALUE__: initialValue }) {
     const [setting, setSetting] = useState(initialValue);
 
     useEffect(() => {
-        const localSetting = window.localStorage.getItem(key);
-        if (localSetting !== null) {
-            setSetting(localSetting);
+        function reload() {
+            const localSetting = window.localStorage.getItem(key);
+            if (localSetting !== null) {
+                setSetting(localSetting);
+            }
         }
+
+        reload();
+
+        window.addEventListener("storage", reload);
+
+        return () => window.removeEventListener("storage", reload);
     }, [ key ]);
 
     function updateSetting(value) {

--- a/src/lib/common/index.js
+++ b/src/lib/common/index.js
@@ -6,6 +6,7 @@ export function buildFetchData(schema) {
 
         if (result.errors) {
             console.error(JSON.stringify(result.errors, null, 2));
+            throw result.errors;
         }
 
         result.apiRequests = context.apiRequests ?? 0;

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -22,7 +22,7 @@ import { AnnouncementToast, ToastHub } from "components/toast";
 import { Text } from "components/text";
 import { useRouter } from "next/router";
 import useSetting from "hooks/useSetting";
-import { devModeSetting, revalidationTokenSetting } from "utils/settings";
+import { DeveloperMode, RevalidationToken } from "utils/settings";
 
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import "styles/prism.scss";
@@ -45,7 +45,7 @@ const StyledContainer = styled(Container)`
 
 export default function MyApp({ Component, pageProps }) {
     const [colorTheme, toggleColorTheme] = useColorTheme();
-    const [devModeSettingValue] = useSetting(devModeSetting);
+    const [developerMode] = useSetting(DeveloperMode);
 
     const { lastBuildAt, apiRequests, isVideoPage = false, ...videoPageProps } = pageProps;
     const [ lastVideoPageProps, setLastVideoPageProps ] = useState(() => {
@@ -98,7 +98,7 @@ export default function MyApp({ Component, pageProps }) {
                         <SearchNavigation/>
                     )}
                     <Component {...pageProps}/>
-                    {devModeSettingValue === "enabled" && lastBuildAt && (
+                    {developerMode === DeveloperMode.ENABLED && lastBuildAt && (
                         <PageRevalidation lastBuildAt={lastBuildAt} apiRequests={apiRequests}/>
                     )}
                 </StyledContainer>
@@ -119,7 +119,7 @@ function MultiContextProvider({ providers = [], children }) {
 
 function PageRevalidation({ lastBuildAt, apiRequests }) {
     const router = useRouter();
-    const [secret] = useSetting(revalidationTokenSetting);
+    const [secret] = useSetting(RevalidationToken);
 
     const [isRevalidating, setRevalidating] = useState(false);
 

--- a/src/pages/artist/[artistSlug]/index.js
+++ b/src/pages/artist/[artistSlug]/index.js
@@ -71,11 +71,7 @@ export default function ArtistDetailPage({ artist }) {
     const [ sortBy, setSortBy ] = useState(SONG_A_Z_ANIME);
 
     const themes = artist.performances
-        .flatMap(
-            (performance) => performance.song.themes.map(
-                (theme) => ({ ...theme, ...performance })
-            )
-        )
+        .flatMap((performance) => performance.song.themes)
         .filter((performance) => (
             filterAlias === null ||
             (filterAlias === artist.name && !performance.as) ||
@@ -169,7 +165,12 @@ export default function ArtistDetailPage({ artist }) {
                     </Collapse>
                     <Column style={{ "--gap": "16px" }}>
                         {themes.map((theme) => (
-                            <ThemeSummaryCard key={theme.anime.slug + theme.slug + theme.group} theme={theme} artist={artist}/>
+                            <ThemeSummaryCard
+                                key={theme.anime.slug + theme.slug + theme.group}
+                                theme={theme}
+                                artist={artist}
+                                expandable
+                            />
                         ))}
                     </Column>
                 </Column>
@@ -206,6 +207,8 @@ export async function getStaticProps({ params: { artistSlug } }) {
                             group
                             anime {
                                 slug
+                                year
+                                season
                             }
                         }
                     }

--- a/src/pages/design.js
+++ b/src/pages/design.js
@@ -405,10 +405,7 @@ export default function DesignPage({ demoData }) {
                         `}
                     </Highlight>
                 </pre>
-                <AnimeSummaryCard
-                    anime={demoData.anime}
-                    previewThemes={1}
-                />
+                <AnimeSummaryCard anime={demoData.anime}/>
             </ExampleGrid>
 
             <Text variant="h2">Input</Text>

--- a/src/pages/profile/index.js
+++ b/src/pages/profile/index.js
@@ -11,10 +11,10 @@ import theme from "theme";
 import { SearchFilter, SearchFilterGroup } from "components/search-filter";
 import { Listbox } from "components/listbox";
 import {
-    devModeSetting,
-    featuredThemePreviewSetting,
-    revalidationTokenSetting,
-    showAnnouncementsSetting
+    DeveloperMode,
+    FeaturedThemePreview,
+    RevalidationToken,
+    ShowAnnouncements
 } from "utils/settings";
 import useSetting from "hooks/useSetting";
 import { Input } from "components/input";
@@ -45,10 +45,10 @@ export default function ProfilePage() {
     const { localPlaylist } = useLocalPlaylist();
     const { history, clearHistory } = useWatchHistory();
 
-    const [showAnnouncementsSettingValue, setShowAnnouncementsSettingValue] = useSetting(showAnnouncementsSetting);
-    const [featuredThemePreviewSettingValue, setFeaturedThemePreviewSettingValue] = useSetting(featuredThemePreviewSetting);
-    const [devModeSettingValue, setDevModeSettingValue] = useSetting(devModeSetting);
-    const [revalidationTokenSettingValue, setRevalidationTokenSettingValue] = useSetting(revalidationTokenSetting);
+    const [showAnnouncements, setShowAnnouncements] = useSetting(ShowAnnouncements);
+    const [featuredThemePreview, setFeaturedThemePreview] = useSetting(FeaturedThemePreview);
+    const [developerMode, setDeveloperMode] = useSetting(DeveloperMode);
+    const [revalidationToken, setRevalidationToken] = useSetting(RevalidationToken);
 
     return (
         <>
@@ -64,34 +64,32 @@ export default function ProfilePage() {
                     <SearchFilterGroup>
                         <SearchFilter>
                             <Text>Show Announcements</Text>
-                            <Listbox value={showAnnouncementsSettingValue} onChange={setShowAnnouncementsSettingValue}>
-                                {Object.entries(showAnnouncementsSetting.values).map(([ value, label ]) => (
-                                    <Listbox.Option key={value} value={value}>{label}</Listbox.Option>
-                                ))}
+                            <Listbox value={showAnnouncements} onChange={setShowAnnouncements}>
+                                <Listbox.Option value={ShowAnnouncements.ENABLED}>Enabled</Listbox.Option>
+                                <Listbox.Option value={ShowAnnouncements.DISABLED}>Disabled</Listbox.Option>
                             </Listbox>
                         </SearchFilter>
                         <SearchFilter>
                             <Text>Featured Theme Preview</Text>
-                            <Listbox value={featuredThemePreviewSettingValue} onChange={setFeaturedThemePreviewSettingValue}>
-                                {Object.entries(featuredThemePreviewSetting.values).map(([ value, label ]) => (
-                                    <Listbox.Option key={value} value={value}>{label}</Listbox.Option>
-                                ))}
+                            <Listbox value={featuredThemePreview} onChange={setFeaturedThemePreview}>
+                                <Listbox.Option value={FeaturedThemePreview.VIDEO}>Video</Listbox.Option>
+                                <Listbox.Option value={FeaturedThemePreview.COVER}>Cover</Listbox.Option>
+                                <Listbox.Option value={FeaturedThemePreview.DISABLED}>Disabled</Listbox.Option>
                             </Listbox>
                         </SearchFilter>
                         <SearchFilter>
                             <Text>Developer Mode</Text>
-                            <Listbox value={devModeSettingValue} onChange={setDevModeSettingValue}>
-                                {Object.entries(devModeSetting.values).map(([ value, label ]) => (
-                                    <Listbox.Option key={value} value={value}>{label}</Listbox.Option>
-                                ))}
+                            <Listbox value={developerMode} onChange={setDeveloperMode}>
+                                <Listbox.Option value={DeveloperMode.DISABLED}>Disabled</Listbox.Option>
+                                <Listbox.Option value={DeveloperMode.ENABLED}>Enabled</Listbox.Option>
                             </Listbox>
                         </SearchFilter>
-                        {devModeSettingValue === "enabled" && (
+                        {developerMode === DeveloperMode.ENABLED && (
                             <SearchFilter>
                                 <Text>Revalidation Token</Text>
                                 <Input
-                                    value={revalidationTokenSettingValue}
-                                    onChange={setRevalidationTokenSettingValue}
+                                    value={revalidationToken}
+                                    onChange={setRevalidationToken}
                                     icon={faKey}
                                 />
                             </SearchFilter>

--- a/src/pages/series/[seriesSlug]/index.js
+++ b/src/pages/series/[seriesSlug]/index.js
@@ -61,7 +61,7 @@ export default function SeriesDetailPage({ series }) {
                     </Collapse>
                     <Column style={{ "--gap": "16px" }}>
                         {animeSorted.map((anime) => (
-                            <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
+                            <AnimeSummaryCard key={anime.slug} anime={anime} expandable/>
                         ))}
                     </Column>
                 </Column>

--- a/src/pages/studio/[studioSlug]/index.js
+++ b/src/pages/studio/[studioSlug]/index.js
@@ -91,7 +91,7 @@ export default function StudioDetailPage({ studio }) {
                     </Collapse>
                     <Column style={{ "--gap": "16px" }}>
                         {animeSorted.map((anime) => (
-                            <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
+                            <AnimeSummaryCard key={anime.slug} anime={anime} expandable/>
                         ))}
                     </Column>
                 </Column>

--- a/src/pages/year/[year]/[season]/index.js
+++ b/src/pages/year/[year]/[season]/index.js
@@ -24,7 +24,7 @@ export default function SeasonDetailPage({ animeAll, year, season }) {
             </Text>
             <Column style={{ "--gap": "16px" }}>
                 {animeList.map((anime) => (
-                    <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
+                    <AnimeSummaryCard key={anime.slug} anime={anime} expandable/>
                 ))}
             </Column>
         </>

--- a/src/pages/year/[year]/index.js
+++ b/src/pages/year/[year]/index.js
@@ -31,7 +31,7 @@ function SeasonPreview({ season, year, animeList }) {
             <Text variant="h2">{season}</Text>
             <Column style={{ "--gap": "16px" }}>
                 {animeList.map((anime) => (
-                    <AnimeSummaryCard key={anime.slug} anime={anime} previewThemes expandable/>
+                    <AnimeSummaryCard key={anime.slug} anime={anime} expandable/>
                 ))}
             </Column>
             <Row style={{ "--justify-content": "center" }}>

--- a/src/styles/animations.js
+++ b/src/styles/animations.js
@@ -17,9 +17,9 @@ export const fadeIn = keyframes`
     }
 `;
 
-export const slideIn = (y = "100%") => keyframes`
+export const slideIn = (y = "100%", x = "0") => keyframes`
     from {
-        transform: translateY(${y});
+        transform: translate(${x}, ${y});
     }
 `;
 

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -97,23 +97,22 @@ export default createGlobalStyle`
         border-color: ${theme.colors["text-disabled"]};
     }
 
-    @media (min-device-width: 600px) {
-        html {
-            scrollbar-color: ${theme.colors["gray-700"]} transparent;
-            scrollbar-width: thin;
-        }
+    html {
+        scrollbar-color: ${theme.colors["gray-700"]} transparent;
+        scrollbar-width: thin;
+    }
 
-        ::-webkit-scrollbar {
-            width: 6px;
-            background-color: transparent;
-        }
+    ::-webkit-scrollbar {
+        width: 6px;
+        height: 3px;
+        background-color: transparent;
+    }
 
-        ::-webkit-scrollbar-thumb {
-            background-color: ${theme.colors["gray-700"]};
+    ::-webkit-scrollbar-thumb {
+        background-color: ${theme.colors["gray-700"]};
 
-            &:hover {
-                background-color: ${theme.colors["gray-500"]};
-            }
+        &:hover {
+            background-color: ${theme.colors["gray-500"]};
         }
     }
 `;

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -1,32 +1,31 @@
-export const showAnnouncementsSetting = {
-    key: "showAnnouncements",
-    initialValue: "enabled",
-    values: {
-        enabled: "Enabled",
-        disabled: "Disabled"
-    }
-};
+export const ShowAnnouncements = Object.freeze({
+    __KEY__: "showAnnouncements",
+    __INITIAL_VALUE__: "enabled",
+    ENABLED: "enabled",
+    DISABLED: "disabled",
+});
 
-export const featuredThemePreviewSetting = {
-    key: "featuredThemePreview",
-    initialValue: "video",
-    values: {
-        video: "Video",
-        cover: "Cover",
-        disabled: "Disabled"
-    }
-};
+export const FeaturedThemePreview = Object.freeze({
+    __KEY__: "featuredThemePreview",
+    __INITIAL_VALUE__: "video",
+    VIDEO: "video",
+    COVER: "cover",
+    DISABLED: "disabled",
+});
 
-export const devModeSetting = {
-    key: "devMode",
-    initialValue: "disabled",
-    values: {
-        disabled: "Disabled",
-        enabled: "Enabled"
-    }
-};
+export const DeveloperMode = Object.freeze({
+    __KEY__: "devMode",
+    __INITIAL_VALUE__: "disabled",
+    DISABLED: "disabled",
+    ENABLED: "enabled",
+});
 
-export const revalidationTokenSetting = {
-    key: "revalidationToken",
-    initialValue: undefined
-};
+export const RevalidationToken = Object.freeze({
+    __KEY__: "revalidationToken",
+    __INITIAL_VALUE__: undefined,
+});
+
+export const GlobalVolume = Object.freeze({
+    __KEY__: "volume",
+    __INITIAL_VALUE__: 1
+});


### PR DESCRIPTION
* Replaced list of themes in anime summary card with table.
* Made expandable summary card expand when clicking anywhere on the card.
* Removed inline theme buttons from anime summary card.
* Made summary card buttons only show on hover.
* Made theme summary cards expandable when multiple artists are performing the theme.
* Split theme entry info into "episode count" and "content warning" in theme table.
* Improved featured theme design on mobile displays.
* Added grills to mobile displays.
* Made featured theme background clickable to link to the video page.
* Added support for sorting while searching.
* Fixed wrong text color of switcher items.
* Added global volume setting.
* Made settings sync across browser tabs.
* Revamped settings system (by removing magic strings).
* Added share button to video page.
* Fixed artist performance sort by anime premiere.
* Made horizontal scrollbars visible and styled.