### PR TITLE
chore: decouple verbose logging from Staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ NEXT_PUBLIC_APP_URL=https://app.animethemes.moe
 ; Set to any truthy value to activate staging mode.
 ; In staging mode a warning banner is displayed at the top of the page.
 NEXT_PUBLIC_STAGING=true
+
+; To enable verbose logging.
+NEXT_PUBLIC_VERBOSE_LOGS=true
 ```
 
 For more information on environment variables see the [Next.js documentation](https://nextjs.org/docs/basic-features/environment-variables).

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -24,6 +24,8 @@ const AUDIO_URL = process.env.NEXT_PUBLIC_AUDIO_URL;
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL;
 
 const STAGING = !!process.env.NEXT_PUBLIC_STAGING;
+const VERBOSE_LOGS = !!process.env.NEXT_PUBLIC_VERBOSE_LOGS;
+
 
 function validateConfig() {
     let isValid = true;
@@ -58,5 +60,6 @@ module.exports = {
     AUDIO_URL,
     APP_URL,
     STAGING,
+    VERBOSE_LOGS,
     validateConfig,
 };

--- a/src/utils/devLog.ts
+++ b/src/utils/devLog.ts
@@ -1,5 +1,5 @@
 import * as log from "next/dist/build/output/log";
-import { STAGING } from "./config";
+import { VERBOSE_LOGS } from "./config";
 
 function info(...message: string[]) {
     logIfDevelopment(log.info, ...message);
@@ -14,7 +14,7 @@ function error(...message: string[]) {
 }
 
 function logIfDevelopment(fn: (...message: string[]) => void, ...message: string[]) {
-    if (process.env.NODE_ENV === "development" || STAGING) {
+    if (process.env.NODE_ENV === "development" || VERBOSE_LOGS) {
         fn(...message);
     }
 }


### PR DESCRIPTION
- In ``config.js``, the environment variable is loaded as ``VERBOSE_LOGS``

- Also updated readme:

```ini
; To enable verbose logging.
NEXT_PUBLIC_VERBOSE_LOGS=true
```