### PR TITLE
feat: add back to top button to index pages

### DIFF
--- a/src/components/button/BackToTopButton.tsx
+++ b/src/components/button/BackToTopButton.tsx
@@ -1,0 +1,57 @@
+import styled, { keyframes } from "styled-components";
+import { Button } from "./Button";
+import { Icon } from "components/icon";
+import { faChevronUp } from "@fortawesome/pro-solid-svg-icons";
+import { useState, useEffect } from "react";
+import theme from "theme";
+import { withHover } from "styles/mixins";
+import { fadeIn } from "styles/animations";
+
+const ScrollButton = styled(Button)`
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  padding: 1rem;
+
+  display: ${(props) => props.isVisible ? "" : "none"};
+  animation: ${fadeIn} 200ms both;
+  
+  ${withHover`
+    background-color: ${theme.colors["solid-on-card"]}; 
+    color: ${theme.colors["text-primary"]}; 
+  `}
+`;
+
+export function BackToTopButton() {
+  const [isButtonVisible, setIsButtonVisible] = useState(false);
+  
+  useEffect(() => {
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 2000) {
+        setIsButtonVisible(true);
+      } else {
+        setIsButtonVisible(false);
+      }
+    });
+  }, []);
+
+  const scrollUp = () => {
+        
+    window.scrollTo({
+      top: 0,
+      behavior: "auto",
+    });
+  };
+
+  return (
+    <ScrollButton
+      variant="primary"
+      isCircle={true}
+      onClick={scrollUp}
+      isVisible={isButtonVisible}
+      
+    >
+      <Icon icon={faChevronUp} />
+    </ScrollButton>
+  );
+}

--- a/src/components/button/BackToTopButton.tsx
+++ b/src/components/button/BackToTopButton.tsx
@@ -1,21 +1,22 @@
-import styled, { keyframes } from "styled-components";
+import styled from "styled-components";
 import { Button } from "./Button";
 import { Icon } from "components/icon";
 import { faChevronUp } from "@fortawesome/pro-solid-svg-icons";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import theme from "theme";
 import { withHover } from "styles/mixins";
-import { fadeIn } from "styles/animations";
+import { slideIn, slideOut } from "styles/animations";
 
 const ScrollButton = styled(Button)`
   position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  padding: 1rem;
+  right: 16px;
+  bottom: 16px;
+  padding: 16px;
 
-  display: ${(props) => props.isVisible ? "" : "none"};
-  animation: ${fadeIn} 200ms both;
-  
+  visibility: ${(props) => (props.isVisible ? "visible" : "hidden")};
+  animation: ${(props) => props.animation} 200ms both;
+  transition: all 200ms;
+
   ${withHover`
     background-color: ${theme.colors["solid-on-card"]}; 
     color: ${theme.colors["text-primary"]}; 
@@ -24,32 +25,36 @@ const ScrollButton = styled(Button)`
 
 export function BackToTopButton() {
   const [isButtonVisible, setIsButtonVisible] = useState(false);
-  
+  const [animation, setAnimation] = useState(slideIn());
+
   useEffect(() => {
-    window.addEventListener("scroll", () => {
+    function handleScroll() {
       if (window.scrollY > 2000) {
         setIsButtonVisible(true);
+        setAnimation(slideIn());
       } else {
         setIsButtonVisible(false);
+        setAnimation(slideOut("150%", "0"));
       }
-    });
+    }
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const scrollUp = () => {
-        
+  function scrollUp() {
     window.scrollTo({
       top: 0,
-      behavior: "auto",
+      behavior: "smooth",
     });
-  };
-
+  }
   return (
     <ScrollButton
       variant="primary"
       isCircle={true}
       onClick={scrollUp}
       isVisible={isButtonVisible}
-      
+      animation={animation}
+      onMouseDown={(event:React.PointerEvent) => event.preventDefault()}
     >
       <Icon icon={faChevronUp} />
     </ScrollButton>

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -2,3 +2,4 @@ export { Button } from "./Button";
 export { VideoButton } from "./VideoButton";
 export { FilterToggleButton } from "./FilterToggleButton";
 export { IconTextButton } from "./IconTextButton";
+export { BackToTopButton } from "./BackToTopButton"

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -36,8 +36,8 @@ const StyledSocialList = styled(Row)`
     }
 
     // To avoid overlap with scroll back to top button as window width gets smaller
-    @media (max-width: 1225px) and (min-width:${theme.breakpoints.mobileMax}) {
-        margin-right: 4rem;
+    @media (max-width: ${theme.breakpoints.socialListMax}) and (min-width:${theme.breakpoints.mobileMax}) {
+        margin-right: 64px;
     }
     
 `;

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -29,11 +29,17 @@ const StyledSocialList = styled(Row)`
     justify-content: flex-end;
     align-items: flex-end;
     gap: 4px;
-
+    
     @media (max-width: ${theme.breakpoints.mobileMax}) {
         flex-basis: 100%;
         justify-content: flex-start;
     }
+
+    // To avoid overlap with scroll back to top button as window width gets smaller
+    @media (max-width: 1225px) and (min-width:${theme.breakpoints.mobileMax}) {
+        margin-right: 4rem;
+    }
+    
 `;
 
 const StyledSocialButton = styled(Button).attrs({ variant: "silent", isCircle: true })`

--- a/src/pages/anime/index.tsx
+++ b/src/pages/anime/index.tsx
@@ -8,11 +8,13 @@ import type { GetStaticProps } from "next";
 import { fetchData } from "lib/server";
 import gql from "graphql-tag";
 import type { AnimeIndexPageQuery } from "generated/graphql";
+import { BackToTopButton } from "components/button";
 
 interface AnimeIndexPageProps extends SharedPageProps, AnimeIndexPageQuery {}
 
 export default function AnimeIndexPage({ animeAll }: AnimeIndexPageProps) {
     return <>
+        <BackToTopButton/>
         <Text variant="h1">Anime Index</Text>
         <AlphabeticalIndex items={animeAll}>
             {(anime) => (

--- a/src/pages/artist/index.tsx
+++ b/src/pages/artist/index.tsx
@@ -8,11 +8,13 @@ import type { GetStaticProps } from "next";
 import { fetchData } from "lib/server";
 import gql from "graphql-tag";
 import type { ArtistIndexPageQuery } from "generated/graphql";
+import { BackToTopButton } from "components/button";
 
 interface ArtistIndexPageProps extends SharedPageProps, ArtistIndexPageQuery {}
 
 export default function ArtistIndexPage({ artistAll }: ArtistIndexPageProps) {
     return <>
+        <BackToTopButton/>
         <Text variant="h1">Artist Index</Text>
         <AlphabeticalIndex items={artistAll}>
             {(artist) => (

--- a/src/pages/series/index.tsx
+++ b/src/pages/series/index.tsx
@@ -8,11 +8,13 @@ import type { GetStaticProps } from "next";
 import { fetchData } from "lib/server";
 import gql from "graphql-tag";
 import type { SeriesIndexPageQuery } from "generated/graphql";
+import { BackToTopButton } from "components/button";
 
 interface SeriesIndexPageProps extends SharedPageProps, SeriesIndexPageQuery {}
 
 export default function SeriesIndexPage({ seriesAll }: SeriesIndexPageProps) {
     return <>
+        <BackToTopButton/>
         <Text variant="h1">Series Index</Text>
         <AlphabeticalIndex items={seriesAll}>
             {(series) => (

--- a/src/pages/studio/index.tsx
+++ b/src/pages/studio/index.tsx
@@ -8,11 +8,13 @@ import type { GetStaticProps } from "next";
 import { fetchData } from "lib/server";
 import gql from "graphql-tag";
 import type { StudioIndexPageQuery } from "generated/graphql";
+import { BackToTopButton } from "components/button";
 
 interface StudioIndexPageProps extends SharedPageProps, StudioIndexPageQuery {}
 
 export default function StudioIndexPage({ studioAll }: StudioIndexPageProps) {
     return <>
+        <BackToTopButton/>
         <Text variant="h1">Studio Index</Text>
         <AlphabeticalIndex items={studioAll}>
             {(studio) => (

--- a/src/pages/wiki/index.tsx
+++ b/src/pages/wiki/index.tsx
@@ -8,12 +8,14 @@ import gql from "graphql-tag";
 import type { DocumentIndexPageQuery } from "generated/graphql";
 import { TextLink } from "components/text/TextLink";
 import { AlphabeticalIndex } from "components/index";
+import { BackToTopButton } from "components/button";
 
 interface DocumentIndexPageProps extends SharedPageProps, DocumentIndexPageQuery {}
 
 export default function DocumentIndexPage({ pageAll }: DocumentIndexPageProps) {
     return <>
         <SEO title="Wiki"/>
+        <BackToTopButton/>
         <Text variant="h1">Wiki</Text>
         <AlphabeticalIndex items={pageAll}>
             {(page) => (

--- a/src/pages/year/index.tsx
+++ b/src/pages/year/index.tsx
@@ -10,6 +10,7 @@ import { TextLink } from "components/text/TextLink";
 import { Text } from "components/text";
 import { Card } from "components/card";
 import theme from "theme";
+import { BackToTopButton } from "components/button";
 
 const StyledYearGrid = styled.div`
     display: grid;
@@ -39,6 +40,7 @@ export default function YearIndexPage({ yearAll }: YearIndexPageProps) {
     return (
         <>
             <SEO title="Browse by Year"/>
+            <BackToTopButton/>
             <Text variant="h1">Year Index</Text>
             <StyledYearGrid>
                 {yearAll.map((year) => (

--- a/src/styles/animations.ts
+++ b/src/styles/animations.ts
@@ -17,8 +17,20 @@ export const fadeIn = keyframes`
     }
 `;
 
+export const fadeOut = keyframes`
+    to {
+        opacity: 0;
+    }
+`;
+
 export const slideIn = (y = "100%", x = "0") => keyframes`
     from {
+        transform: translate(${x}, ${y});
+    }
+`;
+
+export const slideOut = (y = "100%", x = "0") => keyframes`
+    to {
         transform: translate(${x}, ${y});
     }
 `;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -31,6 +31,7 @@ const theme: Theme = {
         tabletMin: "721px",
         tabletMax: "870px",
         desktopMin: "871px",
+        socialListMax: "1225px",
     },
     shadows: createThemeDefinition(shadows),
     colors: createThemeDefinition(colors),


### PR DESCRIPTION
<details>
  </br>
  <summary>03/25/2023 Demo (old)</summary>
  
[old back to top button demo](https://user-images.githubusercontent.com/97417536/227740456-9ec8c8ff-bead-4ed3-be56-a0a17378aa92.mov)
</details>

## 4/3/2023 Update:

After working on the feedback, the following has been implemented:
- Slide in and slide out animation. Created ``slideOut()`` animation keyframe function using ``slideIn()`` as reference
- Change scroll behavior to ``smooth``
- Due to experimenting with various animation effects on the button, a ``fadeOut`` animation keyframe was added
- Added clean up function to the ``useEffect`` for removing the window event listener when the component unmounts
- Added a constant media breakpoint value ``socialListMax``. The reason for such is to avoid overlap between the social media buttons and the scroll button as the window shrinks. I can provide a recording to showcase this if you'd like :)
- replace ``rem`` with the equivalent ``px`` values

Also, please let me know if there are any more linting issues and unnecessary empty lines in case I missed some 👍 

Here's a new demo of what the button looks like now: 

[back to top button demo](https://user-images.githubusercontent.com/97417536/229433442-dae3808d-465b-4fef-a3ad-099ad1b6aeda.mov)



