### PR TITLE
fix: increase slideOut distance and use display property

### DIFF
--- a/src/components/button/BackToTopButton.tsx
+++ b/src/components/button/BackToTopButton.tsx
@@ -13,54 +13,60 @@ const ScrollButton = styled(Button)<{ $bottomOffset: number }>`
   right: 16px;
   bottom: ${(props) => 16 + props.$bottomOffset}px;
   padding: 16px;
-
-  visibility: ${(props) => (props.isVisible ? "visible" : "hidden")};
-  animation: ${(props) => props.animation} 200ms both;
-  transition: all 200ms;
+  display: ${(props) => (props.isVisible ? "default" : "none")};
+  animation: ${(props) => props.animation} 250ms;
 
   ${withHover`
-    background-color: ${theme.colors["solid-on-card"]}; 
-    color: ${theme.colors["text-primary"]}; 
-  `}
+      background-color: ${theme.colors["solid-on-card"]}; 
+      color: ${theme.colors["text-primary"]}; 
+    `}
 `;
 
 export function BackToTopButton() {
-    const [isButtonVisible, setIsButtonVisible] = useState(false);
-    const [animation, setAnimation] = useState(slideIn());
+  const [isButtonVisible, setIsButtonVisible] = useState(false);
+  const [animation, setAnimation] = useState("slideOut");
 
-    const { currentWatchListItem } = useContext(PlayerContext);
+  const { currentWatchListItem } = useContext(PlayerContext);
 
-    useEffect(() => {
-        function handleScroll() {
-            if (window.scrollY > 2000) {
-                setIsButtonVisible(true);
-                setAnimation(slideIn());
-            } else {
-                setIsButtonVisible(false);
-                setAnimation(slideOut("150%", "0"));
-            }
-        }
-        window.addEventListener("scroll", handleScroll);
-        return () => window.removeEventListener("scroll", handleScroll);
-    }, []);
+  function scrollUp() {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }
 
-    function scrollUp() {
-        window.scrollTo({
-            top: 0,
-            behavior: "smooth",
-        });
+  useEffect(() => {
+    function handleScroll() {
+      if (window.scrollY > 2000) {
+        setIsButtonVisible(true);
+        setAnimation("slideIn");
+      } else {
+        setAnimation("slideOut");
+      }
     }
-    return (
-        <ScrollButton
-            variant="primary"
-            isCircle={true}
-            onClick={scrollUp}
-            isVisible={isButtonVisible}
-            animation={animation}
-            onMouseDown={(event:React.PointerEvent) => event.preventDefault()}
-            $bottomOffset={currentWatchListItem ? 76 : 0}
-        >
-            <Icon icon={faChevronUp} />
-        </ScrollButton>
-    );
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    // Allow the button to slide out before setting display:none using 'isButtonVisible'
+    if (animation === "slideOut") {
+      setTimeout(() => {
+        setIsButtonVisible(false);
+      }, 200);
+    }
+  }, [animation]);
+  return (
+    <ScrollButton
+      variant="primary"
+      isCircle={true}
+      onClick={scrollUp}
+      isVisible={isButtonVisible}
+      animation={animation === "slideIn" ? slideIn() : slideOut("450%", "0%")}
+      onMouseDown={(event: React.PointerEvent) => event.preventDefault()}
+      $bottomOffset={currentWatchListItem ? 76 : 0}
+    >
+      <Icon icon={faChevronUp} />
+    </ScrollButton>
+  );
 }

--- a/src/components/button/BackToTopButton.tsx
+++ b/src/components/button/BackToTopButton.tsx
@@ -5,16 +5,14 @@ import { faChevronUp } from "@fortawesome/pro-solid-svg-icons";
 import React, { useState, useEffect, useContext } from "react";
 import theme from "theme";
 import { withHover } from "styles/mixins";
-import { slideIn, slideOut } from "styles/animations";
 import PlayerContext from "context/playerContext";
+import { AnimatePresence, m } from "framer-motion";
 
-const ScrollButton = styled(Button)<{ $bottomOffset: number }>`
+const ScrollButton = styled(m(Button))<{ $bottomOffset: number }>`
   position: fixed;
   right: 16px;
   bottom: ${(props) => 16 + props.$bottomOffset}px;
   padding: 16px;
-  display: ${(props) => (props.isVisible ? "default" : "none")};
-  animation: ${(props) => props.animation} 250ms;
 
   ${withHover`
       background-color: ${theme.colors["solid-on-card"]}; 
@@ -24,8 +22,6 @@ const ScrollButton = styled(Button)<{ $bottomOffset: number }>`
 
 export function BackToTopButton() {
   const [isButtonVisible, setIsButtonVisible] = useState(false);
-  const [animation, setAnimation] = useState("slideOut");
-
   const { currentWatchListItem } = useContext(PlayerContext);
 
   function scrollUp() {
@@ -39,34 +35,30 @@ export function BackToTopButton() {
     function handleScroll() {
       if (window.scrollY > 2000) {
         setIsButtonVisible(true);
-        setAnimation("slideIn");
       } else {
-        setAnimation("slideOut");
+        setIsButtonVisible(false);
       }
     }
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
-
-  useEffect(() => {
-    // Allow the button to slide out before setting display:none using 'isButtonVisible'
-    if (animation === "slideOut") {
-      setTimeout(() => {
-        setIsButtonVisible(false);
-      }, 200);
-    }
-  }, [animation]);
   return (
-    <ScrollButton
-      variant="primary"
-      isCircle={true}
-      onClick={scrollUp}
-      isVisible={isButtonVisible}
-      animation={animation === "slideIn" ? slideIn() : slideOut("450%", "0%")}
-      onMouseDown={(event: React.PointerEvent) => event.preventDefault()}
-      $bottomOffset={currentWatchListItem ? 76 : 0}
-    >
-      <Icon icon={faChevronUp} />
-    </ScrollButton>
+    <AnimatePresence>
+      {isButtonVisible ? (
+        <ScrollButton
+          key={"scrollButton"}
+          initial={{ y: "150%" }}
+          animate={{ y: "0" }}
+          exit={{ y: "450%" }}
+          variant="primary"
+          isCircle={true}
+          onClick={scrollUp}
+          onMouseDown={(event: React.PointerEvent) => event.preventDefault()}
+          $bottomOffset={currentWatchListItem ? 76 : 0}
+        >
+          <Icon icon={faChevronUp} />
+        </ScrollButton>
+      ) : null}
+    </AnimatePresence>
   );
 }


### PR DESCRIPTION
Back to top button doesn't completely slide off screen on mobile, see demonstration below. 

- Extend slideOut animation distance enough to translate the button off screen.
- Utilize ``display`` css property and ``setTimeout`` function instead of the ``visibility`` property to delay the button from disappearing before the animation plays out. 

Demonstration:

https://github.com/AnimeThemes/animethemes-web/assets/97417536/436a4081-6eee-4a5f-b2a2-42bbfc90a652