### PR TITLE
Back to overview btn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "sass": "^1.43.4",
         "shiki": "^0.14.1",
         "styled-components": "^5.3.3",
-        "swr": "^2.0.0",
+        "swr": "^2.2.4",
         "unist-util-visit": "^4.1.2",
         "use-local-storage-state": "^18.3.0",
         "use-session-storage-state": "^18.1.1"
@@ -10782,14 +10782,12 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.4.tgz",
-      "integrity": "sha512-4GUiTjknRUVuw4MWUHR7mzJ9G/DWL+yZz/TgWDfiA0OZ9tL6qyrTkN2wPeboBpL3OJTkej3pexh3mWCnv8cFkQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
+      "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
       "dependencies": {
+        "client-only": "^0.0.1",
         "use-sync-external-store": "^1.2.0"
-      },
-      "engines": {
-        "pnpm": "7"
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
@@ -19725,10 +19723,11 @@
       }
     },
     "swr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.4.tgz",
-      "integrity": "sha512-4GUiTjknRUVuw4MWUHR7mzJ9G/DWL+yZz/TgWDfiA0OZ9tL6qyrTkN2wPeboBpL3OJTkej3pexh3mWCnv8cFkQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
+      "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
       "requires": {
+        "client-only": "^0.0.1",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "sass": "^1.43.4",
     "shiki": "^0.14.1",
     "styled-components": "^5.3.3",
-    "swr": "^2.0.0",
+    "swr": "^2.2.4",
     "unist-util-visit": "^4.1.2",
     "use-local-storage-state": "^18.3.0",
     "use-session-storage-state": "^18.1.1"

--- a/src/pages/wiki/[...pageSlug]/index.tsx
+++ b/src/pages/wiki/[...pageSlug]/index.tsx
@@ -42,8 +42,8 @@ const ArrowLink = styled(Link)`
     align-self: flex-start;
     display: flex;
     align-items: center;
-    gap: 10px;
-    margin-top: 8px;`;
+    gap: 8px;
+    `;
 
 export interface DocumentPageProps extends SharedPageProps {
     page: Omit<RequiredNonNullable<DocumentPageQuery>["page"], "body"> & {

--- a/src/pages/wiki/[...pageSlug]/index.tsx
+++ b/src/pages/wiki/[...pageSlug]/index.tsx
@@ -1,5 +1,9 @@
+import Link from "next/link";
 import { fetchData } from "lib/server";
 import styled from "styled-components";
+import { Icon } from "components/icon";
+import { faArrowLeft } from "@fortawesome/pro-solid-svg-icons";
+import { Text } from "components/text";
 import theme from "theme";
 import { SEO } from "components/seo";
 import fetchStaticPaths from "utils/fetchStaticPaths";
@@ -34,6 +38,13 @@ const StyledGrid = styled.div`
     }
 `;
 
+const ArrowLink = styled(Link)`
+    align-self: flex-start;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 8px;`;
+
 export interface DocumentPageProps extends SharedPageProps {
     page: Omit<RequiredNonNullable<DocumentPageQuery>["page"], "body"> & {
         source: MDXRemoteSerializeResult;
@@ -47,11 +58,17 @@ interface DocumentPageParams extends ParsedUrlQuery {
 
 export default function DocumentPage({ page }: DocumentPageProps) {
     return (
+        <>
         <StyledGrid>
             <SEO title={page.name}/>
             <Markdown source={page.source} />
             <TableOfContents headings={page.headings} />
         </StyledGrid>
+        <ArrowLink href="/wiki">
+            <Icon icon={faArrowLeft} color="text-disabled"></Icon>
+            <Text link color="text-disabled">Back to overview</Text>
+        </ArrowLink>
+        </>
     );
 }
 

--- a/src/pages/wiki/[...pageSlug]/index.tsx
+++ b/src/pages/wiki/[...pageSlug]/index.tsx
@@ -59,15 +59,15 @@ interface DocumentPageParams extends ParsedUrlQuery {
 export default function DocumentPage({ page }: DocumentPageProps) {
     return (
         <>
-        <StyledGrid>
-            <SEO title={page.name}/>
-            <Markdown source={page.source} />
-            <TableOfContents headings={page.headings} />
-        </StyledGrid>
-        <ArrowLink href="/wiki">
-            <Icon icon={faArrowLeft} color="text-disabled"></Icon>
-            <Text link color="text-disabled">Back to overview</Text>
-        </ArrowLink>
+            <StyledGrid>
+                <SEO title={page.name}/>
+                <Markdown source={page.source} />
+                <TableOfContents headings={page.headings} />
+            </StyledGrid>
+            <ArrowLink href="/wiki">
+                <Icon icon={faArrowLeft} color="text-disabled"/>
+                <Text link color="text-disabled">Back to overview</Text>
+            </ArrowLink>
         </>
     );
 }


### PR DESCRIPTION
Added a back to overview link at the bottom of the wiki pages. It redirects back to /wiki using a styled Next link component. It also includes a small arrow which is a font awesome icon, as well as a text component with a link property. For my project I also had to do an `npm install swr` after the initial `npm install`, as the import was not working, hence the first commit
![image](https://github.com/AnimeThemes/animethemes-web/assets/72024920/3a818ffc-6a08-43a8-88fa-b69717265bb7)
